### PR TITLE
feat: ProfileScreen 백엔드 API 연동 및 마이페이지 카드형 UI 개편

### DIFF
--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -1,21 +1,76 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, Eye, EyeOff, X } from 'lucide-react';
+import {
+  ChevronLeft,
+  Eye,
+  EyeOff,
+  X,
+  Camera,
+  Shield,
+  Mail,
+  User,
+  Calendar,
+  KeyRound,
+  LogOut,
+  AlertTriangle,
+  ChevronRight,
+} from 'lucide-react';
 import client from '../../api/client';
 
 export default function ProfileScreen() {
   const navigate = useNavigate();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const [isEdit, setIsEdit] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [showSaveToast, setShowSaveToast] = useState(false);
+  const [profileImage, setProfileImage] = useState<string | null>(null);
 
   const [user, setUser] = useState({
-    name: '지연 이',
-    email: 'user@clair.app',
-    password: 'password123',
+    name: '',
+    email: '',
+    password: '',
+    createdAt: '',
   });
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const res = await client.get('/api/v1/auth/me');
+
+        setUser({
+          name: res.data.nickname || res.data.name || '사용자',
+          email: res.data.email || '',
+          password: '',
+          createdAt: res.data.created_at || res.data.createdAt || '',
+        });
+
+        setProfileImage(res.data.profile_image || res.data.profileImage || null);
+      } catch (error) {
+        console.error('유저 정보 불러오기 실패:', error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) return;
+
+    const imageUrl = URL.createObjectURL(file);
+    setProfileImage(imageUrl);
+  };
+
+  const handleResetImage = () => {
+    setProfileImage(null);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
 
   const handleSave = () => {
     setIsEdit(false);
@@ -27,9 +82,12 @@ export default function ProfileScreen() {
   };
 
   const handleLogout = () => {
+    localStorage.removeItem('accessToken');
     setShowLogoutModal(false);
     navigate('/login');
   };
+
+  const displayInitial = user.name ? user.name.charAt(0) : 'U';
 
   return (
     <div
@@ -45,6 +103,7 @@ export default function ProfileScreen() {
             <button
               onClick={() => navigate(-1)}
               className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/80 bg-white/80 text-slate-600 shadow-sm backdrop-blur transition hover:bg-white"
+              aria-label="뒤로가기"
             >
               <ChevronLeft className="h-5 w-5" />
             </button>
@@ -67,24 +126,85 @@ export default function ProfileScreen() {
         </header>
 
         <main className="flex flex-1 items-center justify-center py-6">
-          <div className="w-full max-w-[520px]">
+          <div className="w-full max-w-[560px] md:max-w-[620px] lg:max-w-[680px]">
             <section className="rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
               <div className="flex items-center gap-4">
-                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white">
-                  지
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="group relative flex h-14 w-14 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white shadow-sm"
+                  >
+                    {profileImage ? (
+                      <img
+                        src={profileImage}
+                        alt="프로필 이미지"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-[18px] font-semibold">
+                        {displayInitial}
+                      </span>
+                    )}
+
+                    <div className="absolute inset-0 flex items-center justify-center bg-slate-900/35 opacity-0 transition group-hover:opacity-100">
+                      <Camera className="h-5 w-5 text-white" />
+                    </div>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border border-white bg-[#EEF2FF] text-[#4C63D2] shadow-sm"
+                    aria-label="프로필 사진 변경"
+                  >
+                    <Camera className="h-3.5 w-3.5" />
+                  </button>
+
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleImageChange}
+                  />
                 </div>
 
-                <div>
-                  <h1 className="text-[15px] font-semibold text-slate-900">
+                <div className="min-w-0 flex-1">
+                  <h1 className="truncate text-[15px] font-semibold text-slate-900">
                     {user.name}
                   </h1>
-                  <p className="text-[12px] text-slate-500">{user.email}</p>
+                  <p className="truncate text-[12px] text-slate-500">
+                    {user.email}
+                  </p>
+
+                  {isEdit && (
+                    <div className="mt-2 flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="rounded-full bg-[#EEF2F9] px-2.5 py-1 text-[10px] font-medium text-[#6C80DD]"
+                      >
+                        사진 변경
+                      </button>
+
+                      {profileImage && (
+                        <button
+                          type="button"
+                          onClick={handleResetImage}
+                          className="rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-medium text-slate-500"
+                        >
+                          기본 이미지
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             </section>
 
-            <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
-              <div className="space-y-4">
+            <section className="mt-4 overflow-hidden rounded-[20px] border border-white/90 bg-white/90 shadow-sm backdrop-blur">
+              <div className="space-y-4 p-4">
                 <div>
                   <label className="text-[12px] text-slate-400">닉네임</label>
                   <input
@@ -108,6 +228,9 @@ export default function ProfileScreen() {
                     value={user.email}
                     className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-[14px]"
                   />
+                  <p className="mt-1.5 text-[11px] text-slate-400">
+                    이메일은 변경할 수 없어요.
+                  </p>
                 </div>
 
                 <div>
@@ -117,6 +240,7 @@ export default function ProfileScreen() {
                       type={showPassword ? 'text' : 'password'}
                       disabled={!isEdit}
                       value={user.password}
+                      placeholder="새 비밀번호 입력"
                       onChange={(e) =>
                         setUser({ ...user, password: e.target.value })
                       }
@@ -125,12 +249,170 @@ export default function ProfileScreen() {
                     <button
                       type="button"
                       onClick={() => setShowPassword(!showPassword)}
-                      className="h-10 w-10 rounded-xl border border-slate-200 bg-white"
+                      className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-white"
                     >
                       {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                     </button>
                   </div>
+                  <p className="mt-1.5 text-[11px] text-slate-400">
+                    비밀번호를 입력한 경우에만 변경됩니다.
+                  </p>
                 </div>
+              </div>
+
+              {isEdit && (
+                <div className="flex gap-2 border-t border-slate-100 p-4">
+                  <button
+                    type="button"
+                    onClick={() => setIsEdit(false)}
+                    className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-[13px] font-semibold text-slate-600"
+                  >
+                    취소
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    className="flex-1 rounded-xl bg-gradient-to-r from-[#7C8CF5] to-[#8EA2FF] py-2.5 text-[13px] font-semibold text-white shadow-sm transition hover:opacity-90"
+                  >
+                    저장
+                  </button>
+                </div>
+              )}
+            </section>
+
+            <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EEF2FF]">
+                  <Shield className="h-5 w-5 text-[#6C80DD]" />
+                </div>
+
+                <div>
+                  <h2 className="text-[15px] font-semibold text-slate-900">
+                    계정 정보
+                  </h2>
+                  <p className="text-[12px] text-slate-500">
+                    계정의 기본 정보를 확인해보세요.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 overflow-hidden rounded-2xl border border-slate-100 bg-white">
+                <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
+                  <Mail className="h-4 w-4 text-slate-500" />
+                  <span className="flex-1 text-[13px] font-medium text-slate-800">
+                    이메일 인증
+                  </span>
+                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
+                    인증 완료
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
+                  <User className="h-4 w-4 text-slate-500" />
+                  <span className="flex-1 text-[13px] font-medium text-slate-800">
+                    계정 상태
+                  </span>
+                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
+                    활성
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-3 px-4 py-3">
+                  <Calendar className="h-4 w-4 text-slate-500" />
+                  <span className="flex-1 text-[13px] font-medium text-slate-800">
+                    가입일
+                  </span>
+                  <span className="text-[12px] text-slate-500">
+                    {user.createdAt
+                      ? new Date(user.createdAt).toLocaleDateString()
+                      : '정보 없음'}
+                  </span>
+                </div>
+              </div>
+            </section>
+
+            <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EEF2FF]">
+                  <KeyRound className="h-5 w-5 text-[#6C80DD]" />
+                </div>
+
+                <div>
+                  <h2 className="text-[15px] font-semibold text-slate-900">
+                    보안 관리
+                  </h2>
+                  <p className="text-[12px] text-slate-500">
+                    계정 보안을 관리할 수 있어요.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-3">
+                <button
+                  type="button"
+                  onClick={() => setIsEdit(true)}
+                  className="flex w-full items-center gap-4 rounded-2xl border border-slate-100 bg-white px-5 py-4 text-left transition hover:bg-[#F8FAFF] sm:gap-5 sm:px-6 sm:py-5"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
+                    <KeyRound className="h-4 w-4 text-slate-600" />
+                  </div>
+
+                  <div className="flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      비밀번호 변경
+                    </p>
+
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      주기적인 비밀번호 변경으로 계정을 보호하세요.
+                    </p>
+                  </div>
+
+                  <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setShowLogoutModal(true)}
+                  className="flex w-full items-center gap-4 rounded-2xl border border-slate-100 bg-white px-5 py-4 text-left transition hover:bg-[#F8FAFF] sm:gap-5 sm:px-6 sm:py-5"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
+                    <LogOut className="h-4 w-4 text-slate-600" />
+                  </div>
+
+                  <div className="flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      로그아웃
+                    </p>
+
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      현재 로그인된 계정에서 로그아웃됩니다.
+                    </p>
+                  </div>
+
+                  <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
+                </button>
+
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-4 rounded-2xl border border-red-100 bg-white px-5 py-4 text-left transition hover:bg-[#FFF7F7] sm:gap-5 sm:px-6 sm:py-5"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#FFF5F5]">
+                    <AlertTriangle className="h-4 w-4 text-red-400" />
+                  </div>
+
+                  <div className="flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      계정 탈퇴
+                    </p>
+
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      계정을 삭제하면 모든 데이터가 사라지며 복구할 수 없습니다.
+                    </p>
+                  </div>
+
+                  <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
+                </button>
               </div>
             </section>
 

--- a/src/app/screens/SettingsScreen.tsx
+++ b/src/app/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import client from '../../api/client';
 import {
@@ -16,6 +16,11 @@ type SettingItem = {
   value?: string;
   icon: React.ComponentType<{ className?: string }>;
   path?: string;
+};
+
+type UserInfo = {
+  nickname: string;
+  email: string;
 };
 
 const profileItems: SettingItem[] = [
@@ -139,14 +144,29 @@ export default function SettingsScreen() {
   const [chatOpen, setChatOpen] = useState(false);
   const [contractOpen, setContractOpen] = useState(false);
 
-  const profileSummary = useMemo(
-    () => ({
-      name: '지연 이',
-      email: 'user@clair.app',
-      role: '설정 및 관리',
-    }),
-    []
-  );
+  const [profileSummary, setProfileSummary] = useState({
+    name: '',
+    email: '',
+    role: '설정 및 관리',
+  });
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const res = await client.get('/api/v1/auth/me');
+
+        setProfileSummary({
+          name: res.data.nickname || '사용자',
+          email: res.data.email || '',
+          role: '설정 및 관리',
+        });
+      } catch (error) {
+        console.error('유저 정보 불러오기 실패:', error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
 
   return (
     <div
@@ -202,16 +222,20 @@ export default function SettingsScreen() {
                     className="flex w-full items-center gap-4 text-left sm:gap-[18px]"
                   >
                     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white shadow-sm sm:h-11 sm:w-11">
-                      <span className="text-sm font-semibold sm:text-base">지</span>
+                      <span className="text-sm font-semibold sm:text-base">
+                        {profileSummary.name?.charAt(0)}
+                      </span>
                     </div>
 
                     <div className="min-w-0 flex-1">
                       <h2 className="truncate text-[14px] font-semibold text-slate-900 sm:text-[15px]">
                         {profileSummary.name}
                       </h2>
+
                       <p className="mt-0.5 truncate text-[11px] text-slate-500 sm:text-[12px]">
                         {profileSummary.email}
                       </p>
+
                       <p className="mt-1 inline-flex rounded-full bg-[#EEF2F9] px-2 py-0.5 text-[9px] font-medium text-[#6C80DD] sm:text-[10px]">
                         {profileSummary.role}
                       </p>


### PR DESCRIPTION
## 관련 이슈
Closes #47 

## 변경 사항
- **실제 로그인 유저 세션 연동:** 더미 데이터를 지우고 `GET /api/v1/auth/me` API를 연동하여 실제 닉네임, 이메일, 가입일 등이 마이페이지에 동적으로 바인딩되도록 전환했습니다.
- **아바타 파일 업로드 및 인터랙션 구현:** 숨겨진 파일 인풋을 활용해 이미지 변경 기능을 구현했습니다. 호버 시 카메라 아이콘 오버레이 노출, 이미지 부재 시 닉네임 이니셜 자동 매핑, '기본 이미지로 변경' 버튼 추가로 UX를 개선했습니다.
- **마이페이지 레이아웃 스케일업 및 반응형 최적화:** 대형 화면에서 뷰가 비어 보이지 않도록 최대 폭을 `md:max-w-[620px]`, `lg:max-w-[680px]`로 확장하고 디바이스별 여백을 넓혀 터치 편의성을 확보했습니다.
- **보안 관리 UI 독립 카드화:** 하나의 리스트에 뭉쳐있던 메뉴(비밀번호 변경, 로그아웃, 탈퇴)를 `bg-[#F8FAFF]` 기반의 개별 독립 컴포넌트(Rounded Card)로 쪼개고, 탈퇴 카드는 Red 톤의 경고 색상을 적용하여 인지성을 높였습니다.
- **불필요 더미 요소 제거:** 실제 기능이 없던 '계정 유형' 필드를 삭제하고, 이메일 인증 및 계정 상태를 확인할 수 있는 메타데이터 카드로 정돈했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [x] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 로컬에서 AI 서비스 정상 기동 확인 (`uvicorn src.api.main:app --port 8001`)
- [x] 분석 파이프라인 단계별 동작 확인
- [x] 기존 기능 동작에 영향 없음 확인

## 리뷰어를 위한 참고 사항
- **브랜치 독립성 관련:** 아직 이전 브랜치들이 메인에 머지되지 않은 상태를 고려하여, 엉키지 않게 메인 브랜치에서 새로 브랜치(`feature/clair-profile-screen`)를 파서 독립적으로 작업했습니다. 다른 작업들과 파일이 겹치지 않으므로 독자적인 선행 머지가 가능합니다.
- **프로필 이미지 휘발성 문제:** 현재 프로필 사진 변경은 `URL.createObjectURL`을 사용한 프론트엔드 로컬 미리보기 단계입니다. 새로고침 시 데이터가 유지되지 않는 한계가 있으며, 이는 추후 백엔드 이미지 업로드 API 명세가 확보되는 대로 서버 저장 로직을 추가해 보완할 예정입니다. 이 점 감안하시어 UI 레이아웃과 데이터 바인딩 위주로 검토해 주시면 감사하겠습니다!