### PR TITLE
[Feat] 채팅 세션 관리 API 연동 및 채팅 화면 UX 개선

### DIFF
--- a/src/app/screens/ChatSessionScreen.tsx
+++ b/src/app/screens/ChatSessionScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ChevronLeft,
@@ -14,6 +14,48 @@ import {
 } from 'lucide-react';
 
 import client from '../../api/client';
+
+type RawMessage = {
+  id?: number;
+  sender?: 'USER' | 'AI' | 'user' | 'assistant' | string;
+  role?: 'user' | 'assistant' | string;
+  content?: string;
+  message?: string;
+  text?: string;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type RawSession = {
+  id: number;
+  contract_id?: number | null;
+  title?: string;
+  total_message_count?: number;
+  message_count?: number;
+  messageCount?: number;
+  last_message_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  preview?: string;
+  last_message?: string;
+  first_question?: string | null;
+  last_question?: string | null;
+  last_answer?: string | null;
+  messages?: RawMessage[];
+};
+
+type RawSessionListResponse = {
+  total?: number;
+  sessions?: RawSession[];
+};
+
+type RawMessagesListResponse = {
+  session_id?: number;
+  total?: number;
+  messages?: RawMessage[];
+};
 
 type Message = {
   id: number;
@@ -32,86 +74,99 @@ type Session = {
   messages: Message[];
 };
 
-const initialSessions: Session[] = [
-  {
-    id: 1,
-    title: '근로계약서 검토 상담',
-    createdAt: '2026.04.04',
-    updatedAt: '방금 전',
-    messageCount: 6,
-    preview: '근로계약서의 수습기간 조항이 적절한지 검토해줘.',
-    messages: [
-      {
-        id: 1,
-        role: 'user',
-        text: '근로계약서의 수습기간 조항이 적절한지 검토해줘.',
-        time: '오후 3:10',
-      },
-      {
-        id: 2,
-        role: 'assistant',
-        text: '수습기간의 길이, 감액 비율, 평가 기준이 함께 명시되어 있는지 확인하는 것이 좋아요.',
-        time: '오후 3:11',
-      },
-      {
-        id: 3,
-        role: 'user',
-        text: '퇴사 통보 조항도 같이 봐줘.',
-        time: '오후 3:12',
-      },
-      {
-        id: 4,
-        role: 'assistant',
-        text: '일방적으로 불리한 통보 기간이 설정되어 있지 않은지 확인해볼게요.',
-        time: '오후 3:13',
-      },
-    ],
-  },
-  {
-    id: 2,
-    title: '임대차 계약 상담',
-    createdAt: '2026.04.03',
-    updatedAt: '1시간 전',
-    messageCount: 4,
-    preview: '상가 임대차 계약서의 원상복구 조항이 과도한지 궁금해.',
-    messages: [
-      {
-        id: 1,
-        role: 'user',
-        text: '상가 임대차 계약서의 원상복구 조항이 과도한지 궁금해.',
-        time: '오전 11:02',
-      },
-      {
-        id: 2,
-        role: 'assistant',
-        text: '임차인의 통상적인 사용 범위를 넘는 의무를 지우는지 먼저 확인해봐야 해요.',
-        time: '오전 11:03',
-      },
-    ],
-  },
-  {
-    id: 3,
-    title: '프리랜서 계약 문의',
-    createdAt: '2026.04.02',
-    updatedAt: '어제',
-    messageCount: 5,
-    preview: '저작권 귀속 조항이 프리랜서에게 너무 불리한 것 같아.',
-    messages: [
-      {
-        id: 1,
-        role: 'user',
-        text: '저작권 귀속 조항이 프리랜서에게 너무 불리한 것 같아.',
-        time: '오후 8:41',
-      },
-      {
-        id: 2,
-        role: 'assistant',
-        text: '대가 지급 범위와 2차적 저작물 활용 권한까지 함께 봐야 정확히 판단할 수 있어요.',
-        time: '오후 8:42',
-      },
-    ],
-  },
-];
+const FALLBACK_AI_ANSWER =
+  '이 질문은 현재 선택된 계약서 정보만으로는 정확히 답변하기 어려워요. 계약서 원문이나 관련 조항을 조금 더 구체적으로 입력해주시면, 해당 내용을 기준으로 다시 검토해드릴게요.';
+
+const formatDate = (value?: string | null) => {
+  if (!value) return '-';
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+const formatTime = (value?: string | null) => {
+  if (!value) return '방금 전';
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const normalizeMessage = (message: RawMessage, index: number): Message => {
+  const sender = String(message.sender ?? message.role ?? '').toLowerCase();
+  const rawContent = message.content ?? message.message ?? message.text ?? '';
+
+  const isAssistant =
+    sender === 'ai' ||
+    sender === 'assistant' ||
+    sender === 'bot' ||
+    sender === 'system' ||
+    sender === 'clair' ||
+    sender === 'clair_ai' ||
+    sender === 'claude' ||
+    sender.includes('ai') ||
+    sender.includes('assistant') ||
+    rawContent.includes('계약서를 업로드하거나 질문을 입력해주세요.');
+
+  const isWeakAiAnswer =
+    isAssistant &&
+    (!rawContent.trim() ||
+      rawContent.includes('답변할 수 없습니다') ||
+      rawContent.includes('알 수 없습니다') ||
+      rawContent.includes('정보가 없습니다') ||
+      rawContent.includes('확인할 수 없습니다'));
+
+  return {
+    id: message.id ?? Date.now() + index,
+    role: isAssistant ? 'assistant' : 'user',
+    text: isWeakAiAnswer ? FALLBACK_AI_ANSWER : rawContent,
+    time: formatTime(message.created_at ?? message.createdAt),
+  };
+};
+
+const normalizeSession = (session: RawSession): Session => {
+  const messages = (session.messages ?? []).map(normalizeMessage);
+  const lastMessage = messages[messages.length - 1];
+
+  return {
+    id: session.id,
+    title: session.title ?? `채팅 세션 ${session.id}`,
+    createdAt: formatDate(session.created_at ?? session.createdAt),
+    updatedAt: formatDate(
+      session.last_message_at ?? session.updated_at ?? session.updatedAt
+    ),
+    messageCount:
+      session.total_message_count ??
+      session.message_count ??
+      session.messageCount ??
+      messages.length ??
+      0,
+    preview:
+      session.preview ??
+      session.last_question ??
+      session.first_question ??
+      session.last_message ??
+      lastMessage?.text ??
+      '새로운 상담을 시작해보세요.',
+    messages,
+  };
+};
 
 function SessionListItem({
   session,
@@ -190,7 +245,16 @@ function MessageBubble({ message }: { message: Message }) {
             : 'border border-slate-200 bg-white text-slate-700'
         }`}
       >
+        <p
+          className={`mb-1 text-[10px] font-semibold ${
+            isUser ? 'text-white/80' : 'text-[#6C80DD]'
+          }`}
+        >
+          {isUser ? '나' : 'CLAIR AI'}
+        </p>
+
         <p className="text-[11px] leading-5 sm:text-[12px]">{message.text}</p>
+
         <p
           className={`mt-1 text-[10px] ${
             isUser ? 'text-white/75' : 'text-slate-400'
@@ -206,15 +270,64 @@ function MessageBubble({ message }: { message: Message }) {
 export default function ChatSessionScreen() {
   const navigate = useNavigate();
 
-  const [sessions, setSessions] = useState<Session[]>(initialSessions);
-  const [selectedSessionId, setSelectedSessionId] = useState<number>(1);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [selectedSessionId, setSelectedSessionId] = useState<number>(0);
   const [search, setSearch] = useState('');
   const [messageInput, setMessageInput] = useState('');
-  const [listOpen, setListOpen] = useState(true);
+  const [listOpen, setListOpen] = useState(false);
   const [detailOpen, setDetailOpen] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [answerStatus, setAnswerStatus] = useState<
+    'idle' | 'thinking' | 'done'
+  >('idle');
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchSessions = async () => {
+    try {
+      const res = await client.get<RawSessionListResponse | RawSession[]>(
+        '/api/v1/chat/sessions'
+      );
+
+      const rawSessions = Array.isArray(res.data)
+        ? res.data
+        : res.data.sessions ?? [];
+
+      const normalizedSessions = rawSessions.map(normalizeSession);
+
+      setSessions((prev) => {
+        const selectedDetail = prev.find(
+          (session) =>
+            session.id === selectedSessionId && session.messages.length > 0
+        );
+
+        if (!selectedDetail) return normalizedSessions;
+
+        return normalizedSessions.map((session) =>
+          session.id === selectedDetail.id
+            ? {
+                ...session,
+                messages: selectedDetail.messages,
+              }
+            : session
+        );
+      });
+
+      if (normalizedSessions.length > 0 && selectedSessionId === 0) {
+        setSelectedSessionId(normalizedSessions[0].id);
+      }
+    } catch (error) {
+      console.error('채팅 세션 목록 조회 실패:', error);
+      setSessions([]);
+    }
+  };
+
+  useEffect(() => {
+    fetchSessions();
+  }, []);
 
   const filteredSessions = useMemo(() => {
     return sessions.filter(
@@ -224,10 +337,21 @@ export default function ChatSessionScreen() {
     );
   }, [sessions, search]);
 
+  const visibleSessions = listOpen
+    ? filteredSessions
+    : filteredSessions.slice(0, 5);
+
   const selectedSession =
     sessions.find((session) => session.id === selectedSessionId) ??
     sessions[0] ??
     null;
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'end',
+    });
+  }, [selectedSession?.messages.length, isSending, answerStatus]);
 
   const firstUserMessage =
     selectedSession?.messages.find((message) => message.role === 'user') ?? null;
@@ -242,21 +366,51 @@ export default function ChatSessionScreen() {
       .reverse()
       .find((message) => message.role === 'assistant') ?? null;
 
-  const handleCreateSession = () => {
-    const newSession: Session = {
-      id: Date.now(),
-      title: `새 채팅 세션 ${sessions.length + 1}`,
-      createdAt: '오늘',
-      updatedAt: '방금 전',
-      messageCount: 0,
-      preview: '새로운 상담을 시작해보세요.',
-      messages: [],
-    };
+  const refreshSelectedSession = async (sessionId: number) => {
+    const sessionRes = await client.get<RawSession>(
+      `/api/v1/chat/sessions/${sessionId}`
+    );
 
-    setSessions((prev) => [newSession, ...prev]);
-    setSelectedSessionId(newSession.id);
+    const messageRes = await client.get<RawMessagesListResponse | RawMessage[]>(
+      `/api/v1/chat/sessions/${sessionId}/messages`
+    );
+
+    const rawMessages = Array.isArray(messageRes.data)
+      ? messageRes.data
+      : messageRes.data.messages ?? [];
+
+    const updatedSession = normalizeSession({
+      ...sessionRes.data,
+      messages: rawMessages,
+    });
+
+    setSessions((prev) =>
+      prev.map((session) =>
+        session.id === sessionId ? updatedSession : session
+      )
+    );
+
+    setSelectedSessionId(sessionId);
     setDetailOpen(true);
-    setMessageInput('');
+  };
+
+  const handleCreateSession = async () => {
+    try {
+      const res = await client.post('/api/v1/chat/sessions', {
+        contract_id: null,
+        title: `새 채팅 세션 ${sessions.length + 1}`,
+      });
+
+      const newSession = normalizeSession(res.data);
+
+      setSessions((prev) => [newSession, ...prev]);
+      setSelectedSessionId(newSession.id);
+      setDetailOpen(true);
+      setMessageInput('');
+      setAnswerStatus('idle');
+    } catch (error) {
+      console.error('채팅 세션 생성 실패:', error);
+    }
   };
 
   const handleOpenDeleteModal = (sessionId: number) => {
@@ -269,59 +423,87 @@ export default function ChatSessionScreen() {
     setDeleteTargetId(null);
   };
 
-  const handleConfirmDeleteSession = () => {
+  const handleConfirmDeleteSession = async () => {
     if (deleteTargetId === null) return;
 
-    const next = sessions.filter((session) => session.id !== deleteTargetId);
-    setSessions(next);
+    try {
+      await client.delete(`/api/v1/chat/sessions/${deleteTargetId}`);
 
-    if (selectedSessionId === deleteTargetId) {
-      setSelectedSessionId(next[0]?.id ?? 0);
+      const next = sessions.filter((session) => session.id !== deleteTargetId);
+
+      setSessions(next);
+
+      if (selectedSessionId === deleteTargetId) {
+        setSelectedSessionId(next[0]?.id ?? 0);
+      }
+
+      setShowDeleteModal(false);
+      setDeleteTargetId(null);
+    } catch (error) {
+      console.error('채팅 세션 삭제 실패:', error);
     }
-
-    setShowDeleteModal(false);
-    setDeleteTargetId(null);
   };
 
-  const handleSelectSession = (sessionId: number) => {
-    setSelectedSessionId(sessionId);
-    setDetailOpen(true);
+  const handleSelectSession = async (sessionId: number) => {
+    try {
+      await refreshSelectedSession(sessionId);
+      setAnswerStatus('idle');
+    } catch (error) {
+      console.error('채팅 세션 상세 조회 실패:', error);
+      setSelectedSessionId(sessionId);
+      setDetailOpen(true);
+    }
   };
 
-  const handleSendMessage = () => {
-    if (!messageInput.trim() || !selectedSession) return;
+  const handleSendMessage = async () => {
+    if (!messageInput.trim() || !selectedSession || isSending) return;
 
+    const currentSessionId = selectedSession.id;
     const nextText = messageInput.trim();
 
+    setMessageInput('');
+    setIsSending(true);
+    setAnswerStatus('thinking');
+
+    const optimisticUserMessage: Message = {
+      id: Date.now(),
+      role: 'user',
+      text: nextText,
+      time: '방금 전',
+    };
+
     setSessions((prev) =>
-      prev.map((session) => {
-        if (session.id !== selectedSession.id) return session;
-
-        const userMessage: Message = {
-          id: Date.now(),
-          role: 'user',
-          text: nextText,
-          time: '방금 전',
-        };
-
-        const assistantMessage: Message = {
-          id: Date.now() + 1,
-          role: 'assistant',
-          text: '메시지가 전송되었어요. 이 영역에 실제 챗봇 응답을 연결하면 됩니다.',
-          time: '방금 전',
-        };
-
-        return {
-          ...session,
-          updatedAt: '방금 전',
-          preview: nextText,
-          messageCount: session.messageCount + 2,
-          messages: [...session.messages, userMessage, assistantMessage],
-        };
-      })
+      prev.map((session) =>
+        session.id === currentSessionId
+          ? {
+              ...session,
+              preview: nextText,
+              messageCount: session.messageCount + 1,
+              messages: [...session.messages, optimisticUserMessage],
+            }
+          : session
+      )
     );
 
-    setMessageInput('');
+    try {
+      await client.post(`/api/v1/chat/sessions/${currentSessionId}/messages`, {
+        content: nextText,
+        message_type: 'question',
+      });
+
+      await refreshSelectedSession(currentSessionId);
+
+      setAnswerStatus('done');
+
+      setTimeout(() => {
+        setAnswerStatus('idle');
+      }, 1800);
+    } catch (error) {
+      console.error('메시지 전송 실패:', error);
+      setAnswerStatus('idle');
+    } finally {
+      setIsSending(false);
+    }
   };
 
   return (
@@ -376,7 +558,7 @@ export default function ChatSessionScreen() {
                 <button
                   type="button"
                   onClick={() => setListOpen((prev) => !prev)}
-                  className="flex w-full items-center justify-between gap-3 text-left lg:hidden"
+                  className="flex w-full items-center justify-between gap-3 text-left"
                 >
                   <div>
                     <h2 className="text-[14px] font-semibold text-slate-900">
@@ -396,9 +578,7 @@ export default function ChatSessionScreen() {
                   </div>
                 </button>
 
-                <div
-                  className={`${listOpen ? 'block' : 'hidden'} mt-3 lg:mt-0 lg:block`}
-                >
+                <div className="mt-3">
                   <button
                     type="button"
                     onClick={handleCreateSession}
@@ -429,7 +609,7 @@ export default function ChatSessionScreen() {
                   </div>
 
                   <div className="mt-3 space-y-2.5">
-                    {filteredSessions.map((session) => (
+                    {visibleSessions.map((session) => (
                       <SessionListItem
                         key={session.id}
                         session={session}
@@ -443,6 +623,23 @@ export default function ChatSessionScreen() {
                       <div className="rounded-[16px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center text-[12px] text-slate-400 sm:text-[13px]">
                         검색된 채팅 세션이 없어요.
                       </div>
+                    )}
+
+                    {filteredSessions.length > 5 && (
+                      <button
+                        type="button"
+                        onClick={() => setListOpen((prev) => !prev)}
+                        className="mt-3 flex w-full items-center justify-center gap-1 rounded-xl border border-slate-200 bg-white py-2 text-[11px] font-medium text-slate-500 transition hover:bg-[#F8FAFF]"
+                      >
+                        {listOpen
+                          ? '세션 접기'
+                          : `전체 ${filteredSessions.length}개 보기`}
+                        <ChevronDown
+                          className={`h-3.5 w-3.5 transition-transform ${
+                            listOpen ? 'rotate-180' : ''
+                          }`}
+                        />
+                      </button>
                     )}
                   </div>
                 </div>
@@ -575,6 +772,36 @@ export default function ChatSessionScreen() {
                           {selectedSession.messages.map((message) => (
                             <MessageBubble key={message.id} message={message} />
                           ))}
+
+                          {isSending && (
+                            <div className="flex justify-start">
+                              <div className="max-w-[78%] rounded-[16px] border border-slate-200 bg-white px-3 py-2 text-slate-700">
+                                <p className="mb-1 text-[10px] font-semibold text-[#6C80DD]">
+                                  CLAIR AI
+                                </p>
+                                <p className="text-[11px] leading-5 sm:text-[12px]">
+                                  답변을 작성 중이에요...
+                                </p>
+                                <p className="mt-1 text-[10px] text-slate-400">
+                                  잠시만 기다려주세요
+                                </p>
+                              </div>
+                            </div>
+                          )}
+
+                          {answerStatus === 'done' && (
+                            <div className="text-center text-[10px] text-slate-400">
+                              답변 완료
+                            </div>
+                          )}
+
+                          {selectedSession.messages.length === 0 && !isSending && (
+                            <div className="rounded-xl border border-dashed border-slate-200 bg-white px-4 py-6 text-center text-[12px] text-slate-400">
+                              아직 대화 내역이 없어요.
+                            </div>
+                          )}
+
+                          <div ref={messagesEndRef} />
                         </div>
                       </div>
 
@@ -588,7 +815,7 @@ export default function ChatSessionScreen() {
                           </span>
                         </div>
 
-                        <div className="mt-3 flex items-end gap-2">
+                        <div className="mt-3 flex flex-col gap-2">
                           <textarea
                             value={messageInput}
                             onChange={(e) => setMessageInput(e.target.value)}
@@ -598,16 +825,32 @@ export default function ChatSessionScreen() {
                                 handleSendMessage();
                               }
                             }}
-                            placeholder="이 세션에 메시지를 입력해보세요."
-                            className="min-h-[72px] flex-1 resize-none rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-[12px] outline-none transition focus:border-[#D8E0F5]"
+                            placeholder={
+                              isSending
+                                ? 'AI가 답변을 작성 중이에요.'
+                                : '이 세션에 메시지를 입력해보세요.'
+                            }
+                            disabled={isSending}
+                            className="min-h-[72px] w-full resize-none rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-[12px] outline-none transition focus:border-[#D8E0F5] disabled:cursor-not-allowed disabled:bg-slate-50"
                           />
 
                           <button
                             type="button"
                             onClick={handleSendMessage}
-                            className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#6C80DD] text-white transition hover:opacity-90"
+                            disabled={isSending || !messageInput.trim()}
+                            style={{
+                              backgroundColor:
+                                isSending || !messageInput.trim()
+                                  ? '#D8E0F5'
+                                  : '#6C80DD',
+                              color: '#FFFFFF',
+                            }}
+                            className="inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-xl px-4 text-[12px] font-semibold shadow-sm transition hover:opacity-90 disabled:cursor-not-allowed"
                           >
-                            <Send className="h-4 w-4" />
+                            <Send className="h-4 w-4 text-white" />
+                            <span className="text-white">
+                              {isSending ? '답변 작성 중' : '전송'}
+                            </span>
                           </button>
                         </div>
                       </div>

--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -273,7 +273,11 @@ export default function ProfileScreen() {
                   <button
                     type="button"
                     onClick={handleSave}
-                    className="flex-1 rounded-xl bg-gradient-to-r from-[#7C8CF5] to-[#8EA2FF] py-2.5 text-[13px] font-semibold text-white shadow-sm transition hover:opacity-90"
+                    style={{
+                      backgroundColor: '#EEF2FF',
+                      color: '#4C63D2',
+                    }}
+                    className="flex-1 rounded-xl py-2.5 text-[13px] font-semibold shadow-sm transition"
                   >
                     저장
                   </button>

--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -1,21 +1,76 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, Eye, EyeOff, X } from 'lucide-react';
+import {
+  ChevronLeft,
+  Eye,
+  EyeOff,
+  X,
+  Camera,
+  Shield,
+  Mail,
+  User,
+  Calendar,
+  KeyRound,
+  LogOut,
+  AlertTriangle,
+  ChevronRight,
+} from 'lucide-react';
 import client from '../../api/client';
 
 export default function ProfileScreen() {
   const navigate = useNavigate();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const [isEdit, setIsEdit] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [showSaveToast, setShowSaveToast] = useState(false);
+  const [profileImage, setProfileImage] = useState<string | null>(null);
 
   const [user, setUser] = useState({
-    name: '지연 이',
-    email: 'user@clair.app',
-    password: 'password123',
+    name: '',
+    email: '',
+    password: '',
+    createdAt: '',
   });
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const res = await client.get('/api/v1/auth/me');
+
+        setUser({
+          name: res.data.nickname || res.data.name || '사용자',
+          email: res.data.email || '',
+          password: '',
+          createdAt: res.data.created_at || res.data.createdAt || '',
+        });
+
+        setProfileImage(res.data.profile_image || res.data.profileImage || null);
+      } catch (error) {
+        console.error('유저 정보 불러오기 실패:', error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) return;
+
+    const imageUrl = URL.createObjectURL(file);
+    setProfileImage(imageUrl);
+  };
+
+  const handleResetImage = () => {
+    setProfileImage(null);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
 
   const handleSave = () => {
     setIsEdit(false);
@@ -27,9 +82,12 @@ export default function ProfileScreen() {
   };
 
   const handleLogout = () => {
+    localStorage.removeItem('accessToken');
     setShowLogoutModal(false);
     navigate('/login');
   };
+
+  const displayInitial = user.name ? user.name.charAt(0) : 'U';
 
   return (
     <div
@@ -45,6 +103,7 @@ export default function ProfileScreen() {
             <button
               onClick={() => navigate(-1)}
               className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/80 bg-white/80 text-slate-600 shadow-sm backdrop-blur transition hover:bg-white"
+              aria-label="뒤로가기"
             >
               <ChevronLeft className="h-5 w-5" />
             </button>
@@ -67,24 +126,85 @@ export default function ProfileScreen() {
         </header>
 
         <main className="flex flex-1 items-center justify-center py-6">
-          <div className="w-full max-w-[520px]">
+          <div className="w-full max-w-[560px] md:max-w-[620px] lg:max-w-[680px]">
             <section className="rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
               <div className="flex items-center gap-4">
-                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white">
-                  지
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="group relative flex h-14 w-14 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white shadow-sm"
+                  >
+                    {profileImage ? (
+                      <img
+                        src={profileImage}
+                        alt="프로필 이미지"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-[18px] font-semibold">
+                        {displayInitial}
+                      </span>
+                    )}
+
+                    <div className="absolute inset-0 flex items-center justify-center bg-slate-900/35 opacity-0 transition group-hover:opacity-100">
+                      <Camera className="h-5 w-5 text-white" />
+                    </div>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border border-white bg-[#EEF2FF] text-[#4C63D2] shadow-sm"
+                    aria-label="프로필 사진 변경"
+                  >
+                    <Camera className="h-3.5 w-3.5" />
+                  </button>
+
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleImageChange}
+                  />
                 </div>
 
-                <div>
-                  <h1 className="text-[15px] font-semibold text-slate-900">
+                <div className="min-w-0 flex-1">
+                  <h1 className="truncate text-[15px] font-semibold text-slate-900">
                     {user.name}
                   </h1>
-                  <p className="text-[12px] text-slate-500">{user.email}</p>
+                  <p className="truncate text-[12px] text-slate-500">
+                    {user.email}
+                  </p>
+
+                  {isEdit && (
+                    <div className="mt-2 flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="rounded-full bg-[#EEF2F9] px-2.5 py-1 text-[10px] font-medium text-[#6C80DD]"
+                      >
+                        사진 변경
+                      </button>
+
+                      {profileImage && (
+                        <button
+                          type="button"
+                          onClick={handleResetImage}
+                          className="rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-medium text-slate-500"
+                        >
+                          기본 이미지
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             </section>
 
-            <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
-              <div className="space-y-4">
+            <section className="mt-4 overflow-hidden rounded-[20px] border border-white/90 bg-white/90 shadow-sm backdrop-blur">
+              <div className="space-y-4 p-4">
                 <div>
                   <label className="text-[12px] text-slate-400">닉네임</label>
                   <input
@@ -108,6 +228,9 @@ export default function ProfileScreen() {
                     value={user.email}
                     className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-[14px]"
                   />
+                  <p className="mt-1.5 text-[11px] text-slate-400">
+                    이메일은 변경할 수 없어요.
+                  </p>
                 </div>
 
                 <div>
@@ -117,6 +240,7 @@ export default function ProfileScreen() {
                       type={showPassword ? 'text' : 'password'}
                       disabled={!isEdit}
                       value={user.password}
+                      placeholder="새 비밀번호 입력"
                       onChange={(e) =>
                         setUser({ ...user, password: e.target.value })
                       }
@@ -125,12 +249,170 @@ export default function ProfileScreen() {
                     <button
                       type="button"
                       onClick={() => setShowPassword(!showPassword)}
-                      className="h-10 w-10 rounded-xl border border-slate-200 bg-white"
+                      className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-white"
                     >
                       {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                     </button>
                   </div>
+                  <p className="mt-1.5 text-[11px] text-slate-400">
+                    비밀번호를 입력한 경우에만 변경됩니다.
+                  </p>
                 </div>
+              </div>
+
+              {isEdit && (
+                <div className="flex gap-2 border-t border-slate-100 p-4">
+                  <button
+                    type="button"
+                    onClick={() => setIsEdit(false)}
+                    className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-[13px] font-semibold text-slate-600"
+                  >
+                    취소
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    className="flex-1 rounded-xl bg-gradient-to-r from-[#7C8CF5] to-[#8EA2FF] py-2.5 text-[13px] font-semibold text-white shadow-sm transition hover:opacity-90"
+                  >
+                    저장
+                  </button>
+                </div>
+              )}
+            </section>
+
+            <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EEF2FF]">
+                  <Shield className="h-5 w-5 text-[#6C80DD]" />
+                </div>
+
+                <div>
+                  <h2 className="text-[15px] font-semibold text-slate-900">
+                    계정 정보
+                  </h2>
+                  <p className="text-[12px] text-slate-500">
+                    계정의 기본 정보를 확인해보세요.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 overflow-hidden rounded-2xl border border-slate-100 bg-white">
+                <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
+                  <Mail className="h-4 w-4 text-slate-500" />
+                  <span className="flex-1 text-[13px] font-medium text-slate-800">
+                    이메일 인증
+                  </span>
+                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
+                    인증 완료
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
+                  <User className="h-4 w-4 text-slate-500" />
+                  <span className="flex-1 text-[13px] font-medium text-slate-800">
+                    계정 상태
+                  </span>
+                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
+                    활성
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-3 px-4 py-3">
+                  <Calendar className="h-4 w-4 text-slate-500" />
+                  <span className="flex-1 text-[13px] font-medium text-slate-800">
+                    가입일
+                  </span>
+                  <span className="text-[12px] text-slate-500">
+                    {user.createdAt
+                      ? new Date(user.createdAt).toLocaleDateString()
+                      : '정보 없음'}
+                  </span>
+                </div>
+              </div>
+            </section>
+
+            <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EEF2FF]">
+                  <KeyRound className="h-5 w-5 text-[#6C80DD]" />
+                </div>
+
+                <div>
+                  <h2 className="text-[15px] font-semibold text-slate-900">
+                    보안 관리
+                  </h2>
+                  <p className="text-[12px] text-slate-500">
+                    계정 보안을 관리할 수 있어요.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-3">
+                <button
+                  type="button"
+                  onClick={() => setIsEdit(true)}
+                  className="flex w-full items-center gap-4 rounded-2xl border border-slate-100 bg-white px-5 py-4 text-left transition hover:bg-[#F8FAFF] sm:gap-5 sm:px-6 sm:py-5"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
+                    <KeyRound className="h-4 w-4 text-slate-600" />
+                  </div>
+
+                  <div className="flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      비밀번호 변경
+                    </p>
+
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      주기적인 비밀번호 변경으로 계정을 보호하세요.
+                    </p>
+                  </div>
+
+                  <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setShowLogoutModal(true)}
+                  className="flex w-full items-center gap-4 rounded-2xl border border-slate-100 bg-white px-5 py-4 text-left transition hover:bg-[#F8FAFF] sm:gap-5 sm:px-6 sm:py-5"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
+                    <LogOut className="h-4 w-4 text-slate-600" />
+                  </div>
+
+                  <div className="flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      로그아웃
+                    </p>
+
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      현재 로그인된 계정에서 로그아웃됩니다.
+                    </p>
+                  </div>
+
+                  <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
+                </button>
+
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-4 rounded-2xl border border-red-100 bg-white px-5 py-4 text-left transition hover:bg-[#FFF7F7] sm:gap-5 sm:px-6 sm:py-5"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#FFF5F5]">
+                    <AlertTriangle className="h-4 w-4 text-red-400" />
+                  </div>
+
+                  <div className="flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      계정 탈퇴
+                    </p>
+
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      계정을 삭제하면 모든 데이터가 사라지며 복구할 수 없습니다.
+                    </p>
+                  </div>
+
+                  <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
+                </button>
               </div>
             </section>
 

--- a/src/app/screens/SettingsScreen.tsx
+++ b/src/app/screens/SettingsScreen.tsx
@@ -27,6 +27,8 @@ const profileItems: SettingItem[] = [
   { id: 1, label: '내 정보 조회', icon: User, path: '/profile' },
   { id: 2, label: '닉네임 변경', icon: User, path: '/profile' },
   { id: 3, label: '비밀번호 변경', icon: User, path: '/profile' },
+  { id: 4, label: '계정 정보', icon: User, path: '/profile' },
+  { id: 5, label: '보안 관리', icon: User, path: '/profile' },
 ];
 
 const chatSessionItems: SettingItem[] = [

--- a/src/app/screens/SettingsScreen.tsx
+++ b/src/app/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import client from '../../api/client';
 import {
@@ -16,6 +16,11 @@ type SettingItem = {
   value?: string;
   icon: React.ComponentType<{ className?: string }>;
   path?: string;
+};
+
+type UserInfo = {
+  nickname: string;
+  email: string;
 };
 
 const profileItems: SettingItem[] = [
@@ -139,14 +144,29 @@ export default function SettingsScreen() {
   const [chatOpen, setChatOpen] = useState(false);
   const [contractOpen, setContractOpen] = useState(false);
 
-  const profileSummary = useMemo(
-    () => ({
-      name: '지연 이',
-      email: 'user@clair.app',
-      role: '설정 및 관리',
-    }),
-    []
-  );
+  const [profileSummary, setProfileSummary] = useState({
+    name: '',
+    email: '',
+    role: '설정 및 관리',
+  });
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const res = await client.get('/api/v1/auth/me');
+
+        setProfileSummary({
+          name: res.data.nickname || '사용자',
+          email: res.data.email || '',
+          role: '설정 및 관리',
+        });
+      } catch (error) {
+        console.error('유저 정보 불러오기 실패:', error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
 
   return (
     <div
@@ -202,16 +222,20 @@ export default function SettingsScreen() {
                     className="flex w-full items-center gap-4 text-left sm:gap-[18px]"
                   >
                     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white shadow-sm sm:h-11 sm:w-11">
-                      <span className="text-sm font-semibold sm:text-base">지</span>
+                      <span className="text-sm font-semibold sm:text-base">
+                        {profileSummary.name?.charAt(0)}
+                      </span>
                     </div>
 
                     <div className="min-w-0 flex-1">
                       <h2 className="truncate text-[14px] font-semibold text-slate-900 sm:text-[15px]">
                         {profileSummary.name}
                       </h2>
+
                       <p className="mt-0.5 truncate text-[11px] text-slate-500 sm:text-[12px]">
                         {profileSummary.email}
                       </p>
+
                       <p className="mt-1 inline-flex rounded-full bg-[#EEF2F9] px-2 py-0.5 text-[9px] font-medium text-[#6C80DD] sm:text-[10px]">
                         {profileSummary.role}
                       </p>


### PR DESCRIPTION
## 관련 이슈
Closes #51 

## 변경 사항
* **백엔드 채팅 API 완전 연동 및 외래키 오류 수정**
  * 새 세션 생성 시 발생하던 FK 오류를 막기 위해 `contract_id`를 `null`로 전송하도록 수정했습니다.
  * 세션 목록 및 대화 내역 API 연동을 완료했습니다.
* **유동적인 백엔드 응답 규격 방어 처리**
  * 백엔드 데이터가 배열(`[...]`)이거나 객체 래퍼(`{ sessions: [...] }`) 형태로 내려오는 상황 모두에 대응할 수 있도록 `Array.isArray()` 기반 방어 코드를 추가했습니다.
* **대화 화면 UX 및 상태 표시 개선**
  * 말풍선 상단에 "나", "CLAIR AI" 라벨을 추가하고, `sender` 판별 로직을 확장하여 AI 식별값을 안전하게 파싱합니다.
  * AI 답변 상태("답변 작성 중...", "답변 완료")를 추가하고, 데이터가 부실할 시 가이드 Fallback 문구가 뜨도록 처리했습니다.
  * 전송 버튼 컬러(#6C80DD) 및 상태별 비활성화 무드를 반영했습니다.
* **자동 스크롤 및 선택 세션 고정 처리**
  * 대화가 추가되거나 AI가 답변 중일 때 화면이 하단으로 부드럽게 내려가도록 `useRef` 기반 자동 스크롤을 도입했습니다.
  * 메시지 전송 후 전체 리스트 갱신으로 인해 선택된 방이 풀리는 현상을 해결하고 현재 세션이 유지되도록 `currentSessionId` 고정 로직을 구현했습니다.
* **세션 이력 접기/펼치기 토글 도입**
  * 사이드바 세션이 과하게 길어지는 것을 방지하기 위해 기본 5개 노출 후 펼치기 토글 버튼이 작동하도록 개선했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [x] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 로컬에서 서버 정상 기동 확인 (`npm run dev` 또는 사용 중인 프론트 구동 명령어)
- [x] 관련 API 엔드포인트 Swagger에서 테스트 완료 (일반 세션 생성, 메시지 송수신 흐름 검증)
- [x] 기존 기능 동작에 영향 없음 확인 (기존 헤더, 그라데이션 배경, 검색 및 삭제 모달 디자인 유지 확인)

## 리뷰어를 위한 참고 사항
* **⚠️ 선행 브랜치 의존성 안내:** 현재 이 PR은 아직 `dev`에 머지되지 않은 `feat/profile-ui-fix` 브랜치의 수정 사항(설정 화면 UI 변경점)을 베이스로 포함하고 있습니다. 따라서 이전 프로필 UI 관련 PR이 먼저 머지된 후 해당 컨텍스트 위에서 코드를 검토해 주시는 것이 좋습니다.
* **자동 스크롤 및 세션 유지:** 메시지를 보낸 직후 대화창 포커스가 다른 곳으로 튀지 않고 부드럽게 하단 스크롤되는 UX 흐름이 자연스러운지 중점적으로 확인해 주세요!