### PR TITLE
fix: CORS 프록시 설정 및 로그인·회원가입·홈 화면 API 연동 버그 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev      # Start Vite dev server
+npm run build    # Production build
+```
+
+There are no configured test or lint scripts.
+
+## Architecture
+
+**Stack:** React 18 + TypeScript + Vite, React Router 7, Tailwind CSS v4, MUI + Radix UI (shadcn-style primitives)
+
+**Entry point:** `src/main.tsx` renders a `RouterProvider`. All routes are defined in `src/app/routes.tsx`.
+
+**Screens** live in `src/app/screens/` — each is a full-page component mapped 1:1 to a route. State is local (`useState`/`useEffect`); there is no global state manager.
+
+**UI components** live in two places:
+- `src/app/components/ui/` — shadcn/Radix primitives (button, card, dialog, etc.)
+- MUI components are used directly from `@mui/material` in screens
+
+## API Layer
+
+All HTTP calls go through `src/api/client.ts` (Axios instance):
+- Base URL: `VITE_API_URL` env var, fallback `http://127.0.0.1:8000`
+- Auth: Bearer token read from `localStorage.getItem('accessToken')`, injected via request interceptor
+- 401 handler: redirects to `/login` except for contract polling (`/loading/`) and share (`/share/`) routes
+- API paths follow `/api/v1/*`
+
+`src/api/axiosInstance.js` is a legacy file; prefer `client.ts`.
+
+## Path Aliases
+
+`@` maps to `src/` (configured in both `tsconfig.json` and `vite.config.ts`).
+
+## Styling Conventions
+
+- Tailwind v4 is the primary styling approach
+- Emotion is available via MUI but not used for custom styles
+- Theme variables are in `src/styles/theme.css`; global styles in `src/styles/index.css`
+- Use `clsx` + `tailwind-merge` (`cn` utility) for conditional class merging

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "4.1.12",
+        "@types/node": "^25.9.1",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "4.7.0",
         "tailwindcss": "4.1.12",
@@ -3375,6 +3376,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5666,6 +5678,13 @@
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.1.12",
+    "@types/node": "^25.9.1",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "4.7.0",
     "tailwindcss": "4.1.12",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 
-const BASE_URL = (import.meta as any).env.VITE_API_URL || 'http://127.0.0.1:8000';
+const BASE_URL = (import.meta as any).env.VITE_API_URL || '';
 
 const client: AxiosInstance = axios.create({
   baseURL: BASE_URL,

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -84,4 +84,5 @@ export const router = createBrowserRouter([
 },
 
 
+
 ]);

--- a/src/app/screens/ContractManagementScreen.tsx
+++ b/src/app/screens/ContractManagementScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import client from '../../api/client';
 import {
@@ -16,7 +16,13 @@ import {
   X,
 } from 'lucide-react';
 
-type ContractStatus = '업로드 완료' | '분석 대기' | '분석 완료' | '삭제됨';
+type ContractStatus =
+  | '업로드 완료'
+  | '분석 대기'
+  | '분석 중'
+  | '분석 완료'
+  | '분석 실패'
+  | '삭제됨';
 
 type Contract = {
   id: number;
@@ -31,53 +37,27 @@ type Contract = {
   deletedAt?: string;
 };
 
-const initialContracts: Contract[] = [
-  {
-    id: 1,
-    title: '근로계약서_정규직',
-    category: '근로계약',
-    uploadedAt: '2026.04.05',
-    updatedAt: '방금 전',
-    status: '분석 완료',
-    fileName: 'employment_contract.pdf',
-    size: '1.8MB',
-    summary: '수습기간, 연장근로수당, 퇴사 통보 조항에 대한 검토가 필요한 계약서예요.',
-  },
-  {
-    id: 2,
-    title: '상가임대차계약서',
-    category: '임대차계약',
-    uploadedAt: '2026.04.04',
-    updatedAt: '2시간 전',
-    status: '분석 대기',
-    fileName: 'lease_store.pdf',
-    size: '2.3MB',
-    summary: '원상복구 조항, 관리비 부담, 중도해지 조건을 중심으로 확인 중이에요.',
-  },
-  {
-    id: 3,
-    title: '프리랜서_용역계약서',
-    category: '용역계약',
-    uploadedAt: '2026.04.03',
-    updatedAt: '어제',
-    status: '업로드 완료',
-    fileName: 'freelance_service_contract.pdf',
-    size: '1.2MB',
-    summary: '저작권 귀속, 수정 요청 범위, 대금 지급 시점이 중요한 계약서예요.',
-  },
-  {
-    id: 4,
-    title: '삭제된_비밀유지계약서',
-    category: 'NDA',
-    uploadedAt: '2026.04.01',
-    updatedAt: '2026.04.02',
-    status: '삭제됨',
-    fileName: 'nda_deleted.pdf',
-    size: '980KB',
-    summary: '삭제 이력 확인용 샘플 계약서예요.',
-    deletedAt: '2026.04.04',
-  },
-];
+type RawContract = {
+  id?: number;
+  contract_id?: number;
+  title?: string;
+  name?: string;
+  file_name?: string;
+  filename?: string;
+  original_filename?: string;
+  category?: string;
+  contract_type?: string;
+  uploaded_at?: string;
+  created_at?: string;
+  updated_at?: string;
+  status?: string;
+  analysis_status?: string;
+  file_size?: number;
+  size?: number | string;
+  summary?: string;
+  analysis_summary?: string;
+  deleted_at?: string;
+};
 
 function SectionCard({
   title,
@@ -141,8 +121,10 @@ function ContractListItem({
   const statusStyle =
     contract.status === '분석 완료'
       ? 'bg-emerald-50 text-emerald-600'
-      : contract.status === '분석 대기'
+      : contract.status === '분석 대기' || contract.status === '분석 중'
       ? 'bg-amber-50 text-amber-600'
+      : contract.status === '분석 실패'
+      ? 'bg-rose-50 text-rose-500'
       : contract.status === '삭제됨'
       ? 'bg-rose-50 text-rose-500'
       : 'bg-[#EEF2F9] text-[#6C80DD]';
@@ -212,17 +194,24 @@ function ContractListItem({
 export default function ContractManagementScreen() {
   const navigate = useNavigate();
 
-  const [contracts, setContracts] = useState<Contract[]>(initialContracts);
-  const [selectedContractId, setSelectedContractId] = useState<number>(1);
+  const [contracts, setContracts] = useState<Contract[]>([]);
+  const [deletedContracts, setDeletedContracts] = useState<Contract[]>([]);
+  const [selectedContractId, setSelectedContractId] = useState<number | null>(null);
   const [search, setSearch] = useState('');
+  const [showAllContracts, setShowAllContracts] = useState(false);
+
   const [uploadOpen, setUploadOpen] = useState(true);
   const [listOpen, setListOpen] = useState(true);
   const [detailOpen, setDetailOpen] = useState(true);
   const [deleteHistoryOpen, setDeleteHistoryOpen] = useState(false);
-  const [analysisOpen, setAnalysisOpen] = useState(false);
-  const [selectedFileName, setSelectedFileName] = useState('');
-  const [selectedFileSize, setSelectedFileSize] = useState('');
-  const [analysisNote, setAnalysisNote] = useState('');
+  const [analysisOpen, setAnalysisOpen] = useState(true);
+
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
@@ -230,79 +219,294 @@ export default function ContractManagementScreen() {
   const [showUploadErrorModal, setShowUploadErrorModal] = useState(false);
   const [uploadErrorMessage, setUploadErrorMessage] = useState('');
 
+  const formatDate = (value?: string) => {
+    if (!value) return '-';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  const formatFileSize = (size?: number | string) => {
+    if (!size) return '-';
+    if (typeof size === 'string') return size;
+
+    if (size >= 1024 * 1024) {
+      return `${(size / (1024 * 1024)).toFixed(1)}MB`;
+    }
+
+    return `${Math.max(1, Math.round(size / 1024))}KB`;
+  };
+
+  const isImageFile = (file: File) => {
+    const name = file.name.toLowerCase();
+
+    return (
+      file.type.startsWith('image/') ||
+      name.endsWith('.png') ||
+      name.endsWith('.jpg') ||
+      name.endsWith('.jpeg') ||
+      name.endsWith('.webp')
+    );
+  };
+
+  const isAllowedUploadFile = (file: File) => {
+    const name = file.name.toLowerCase();
+
+    return (
+      file.type === 'application/pdf' ||
+      file.type === 'text/plain' ||
+      file.type.startsWith('image/') ||
+      name.endsWith('.pdf') ||
+      name.endsWith('.txt') ||
+      name.endsWith('.png') ||
+      name.endsWith('.jpg') ||
+      name.endsWith('.jpeg') ||
+      name.endsWith('.webp')
+    );
+  };
+
+  const normalizeStatus = (status?: string): ContractStatus => {
+    const value = String(status ?? '').toLowerCase();
+
+    if (
+      value.includes('complete') ||
+      value.includes('done') ||
+      value.includes('analyzed') ||
+      value.includes('분석 완료')
+    ) {
+      return '분석 완료';
+    }
+
+    if (
+      value.includes('processing') ||
+      value.includes('running') ||
+      value.includes('progress') ||
+      value.includes('분석 중')
+    ) {
+      return '분석 중';
+    }
+
+    if (
+      value.includes('pending') ||
+      value.includes('waiting') ||
+      value.includes('requested') ||
+      value.includes('대기')
+    ) {
+      return '분석 대기';
+    }
+
+    if (value.includes('fail') || value.includes('error') || value.includes('실패')) {
+      return '분석 실패';
+    }
+
+    if (value.includes('delete') || value.includes('삭제')) {
+      return '삭제됨';
+    }
+
+    return '업로드 완료';
+  };
+
+  const normalizeContract = (raw: RawContract): Contract => {
+    const id = raw.id ?? raw.contract_id ?? 0;
+    const fileName =
+      raw.file_name ??
+      raw.filename ??
+      raw.original_filename ??
+      raw.name ??
+      `contract_${id}.pdf`;
+
+    return {
+      id,
+      title: raw.title ?? raw.name ?? fileName.replace(/\.[^/.]+$/, ''),
+      category: raw.category ?? raw.contract_type ?? '기타계약',
+      uploadedAt: formatDate(raw.uploaded_at ?? raw.created_at),
+      updatedAt: raw.updated_at ? formatDate(raw.updated_at) : '-',
+      status: normalizeStatus(raw.analysis_status ?? raw.status),
+      fileName,
+      size: formatFileSize(raw.file_size ?? raw.size),
+      summary: raw.summary ?? raw.analysis_summary ?? '아직 등록된 요약 정보가 없어요.',
+      deletedAt: raw.deleted_at ? formatDate(raw.deleted_at) : undefined,
+    };
+  };
+
+  const extractContractArray = (data: any): RawContract[] => {
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data?.contracts)) return data.contracts;
+    if (Array.isArray(data?.items)) return data.items;
+    if (Array.isArray(data?.data)) return data.data;
+    return [];
+  };
+
+  const fetchContracts = useCallback(async () => {
+    try {
+      setLoading(true);
+
+      const response = await client.get('/api/v1/contracts/');
+      const list = extractContractArray(response.data).map(normalizeContract);
+
+      const activeList = list.filter((contract) => contract.status !== '삭제됨');
+      const deletedList = list.filter((contract) => contract.status === '삭제됨');
+
+      setContracts(activeList);
+      setDeletedContracts(deletedList);
+
+      setSelectedContractId((prev) => {
+        if (prev && activeList.some((contract) => contract.id === prev)) return prev;
+        return activeList[0]?.id ?? null;
+      });
+    } catch {
+      setUploadErrorMessage('계약서 목록을 불러오지 못했어요. 잠시 후 다시 시도해주세요.');
+      setShowUploadErrorModal(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchContractDetail = useCallback(async (contractId: number) => {
+    try {
+      const response = await client.get(`/api/v1/contracts/${contractId}`);
+      const detail = normalizeContract(response.data);
+
+      setContracts((prev) =>
+        prev.map((contract) =>
+          contract.id === contractId ? { ...contract, ...detail } : contract
+        )
+      );
+    } catch {
+      setUploadErrorMessage('계약서 상세 정보를 불러오지 못했어요.');
+      setShowUploadErrorModal(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchContracts();
+  }, [fetchContracts]);
+
+  useEffect(() => {
+    if (selectedContractId) {
+      fetchContractDetail(selectedContractId);
+    }
+  }, [selectedContractId, fetchContractDetail]);
+
   const visibleContracts = useMemo(() => {
     return contracts.filter(
       (contract) =>
-        contract.status !== '삭제됨' &&
-        (contract.title.toLowerCase().includes(search.toLowerCase()) ||
-          contract.category.toLowerCase().includes(search.toLowerCase()) ||
-          contract.fileName.toLowerCase().includes(search.toLowerCase()))
+        contract.title.toLowerCase().includes(search.toLowerCase()) ||
+        contract.category.toLowerCase().includes(search.toLowerCase()) ||
+        contract.fileName.toLowerCase().includes(search.toLowerCase())
     );
   }, [contracts, search]);
 
-  const deletedContracts = useMemo(() => {
-    return contracts.filter((contract) => contract.status === '삭제됨');
-  }, [contracts]);
+  const displayedContracts = useMemo(() => {
+    return showAllContracts ? visibleContracts : visibleContracts.slice(0, 5);
+  }, [visibleContracts, showAllContracts]);
+
+  useEffect(() => {
+    setShowAllContracts(false);
+  }, [search]);
 
   const selectedContract =
     contracts.find((contract) => contract.id === selectedContractId) ??
     visibleContracts[0] ??
     null;
 
-  const formatFileSize = (size: number) => {
-    if (size >= 1024 * 1024) {
-      return `${(size / (1024 * 1024)).toFixed(1)}MB`;
-    }
-    return `${Math.max(1, Math.round(size / 1024))}KB`;
-  };
-
   const handleSelectFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
 
     const maxSize = 10 * 1024 * 1024;
-    const isPdf = file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
 
-    if (!isPdf) {
-      setUploadErrorMessage('PDF 파일만 업로드할 수 있어요.');
+    const validFiles = files.filter((file) => {
+      return isAllowedUploadFile(file) && file.size <= maxSize;
+    });
+
+    if (validFiles.length !== files.length) {
+      setUploadErrorMessage(
+        'PDF, TXT, 이미지 파일만 업로드할 수 있고, 각 파일은 10MB 이하만 가능해요.'
+      );
       setShowUploadErrorModal(true);
-      e.target.value = '';
-      return;
     }
 
-    if (file.size > maxSize) {
-      setUploadErrorMessage('파일 크기는 10MB 이하만 업로드할 수 있어요.');
-      setShowUploadErrorModal(true);
-      e.target.value = '';
-      return;
-    }
+    setSelectedFiles((prev) => {
+      const merged = [...prev];
 
-    setSelectedFileName(file.name);
-    setSelectedFileSize(formatFileSize(file.size));
+      validFiles.forEach((file) => {
+        const alreadyExists = merged.some(
+          (item) =>
+            item.name === file.name &&
+            item.size === file.size &&
+            item.lastModified === file.lastModified
+        );
+
+        if (!alreadyExists) {
+          merged.push(file);
+        }
+      });
+
+      return merged;
+    });
+
+    e.target.value = '';
   };
 
-  const handleUpload = () => {
-    if (!selectedFileName) return;
+  const handleRemoveSelectedFile = (index: number) => {
+    setSelectedFiles((prev) => prev.filter((_, fileIndex) => fileIndex !== index));
+  };
 
-    const newContract: Contract = {
-      id: Date.now(),
-      title: selectedFileName.replace(/\.[^/.]+$/, ''),
-      category: '기타계약',
-      uploadedAt: '오늘',
-      updatedAt: '방금 전',
-      status: '업로드 완료',
-      fileName: selectedFileName,
-      size: selectedFileSize || '업로드 파일',
-      summary: '새로 업로드된 계약서예요. 상세 내용을 확인하거나 분석 요청을 진행할 수 있어요.',
-    };
+  const handleUpload = async () => {
+    if (selectedFiles.length === 0) return;
 
-    setContracts((prev) => [newContract, ...prev]);
-    setSelectedContractId(newContract.id);
-    setSelectedFileName('');
-    setSelectedFileSize('');
-    setUploadOpen(true);
-    setListOpen(true);
-    setDetailOpen(true);
+    try {
+      setUploading(true);
+
+      const imageFiles = selectedFiles.filter(isImageFile);
+      const documentFiles = selectedFiles.filter((file) => !isImageFile(file));
+
+      for (const file of documentFiles) {
+        const formData = new FormData();
+        formData.append('file', file);
+
+        await client.post('/api/v1/contracts/upload', formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        });
+      }
+
+      if (imageFiles.length > 0) {
+        const imageFormData = new FormData();
+
+        imageFiles.forEach((file) => {
+          imageFormData.append('files', file);
+        });
+
+        await client.post('/api/v1/contracts/upload-images', imageFormData, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        });
+      }
+
+      await fetchContracts();
+
+      setSelectedFiles([]);
+      setUploadOpen(true);
+      setListOpen(true);
+      setDetailOpen(true);
+      setShowAllContracts(false);
+    } catch {
+      setUploadErrorMessage(
+        '파일 업로드에 실패했어요. 파일 형식, 용량 또는 백엔드 업로드 필드명을 확인해주세요.'
+      );
+      setShowUploadErrorModal(true);
+    } finally {
+      setUploading(false);
+    }
   };
 
   const handleOpenDeleteModal = (contractId: number) => {
@@ -315,51 +519,58 @@ export default function ContractManagementScreen() {
     setShowDeleteModal(false);
   };
 
-  const handleConfirmDeleteContract = () => {
+  const handleConfirmDeleteContract = async () => {
     if (deleteTargetId === null) return;
 
-    const updatedContracts = contracts.map((contract) =>
-      contract.id === deleteTargetId
-        ? {
-            ...contract,
-            status: '삭제됨' as ContractStatus,
+    const target = contracts.find((contract) => contract.id === deleteTargetId);
+
+    try {
+      setDeleting(true);
+
+      await client.delete(`/api/v1/contracts/${deleteTargetId}`);
+
+      if (target) {
+        setDeletedContracts((prev) => [
+          {
+            ...target,
+            status: '삭제됨',
             updatedAt: '방금 전',
             deletedAt: '오늘',
-          }
-        : contract
-    );
+          },
+          ...prev,
+        ]);
+      }
 
-    setContracts(updatedContracts);
+      const remaining = contracts.filter((contract) => contract.id !== deleteTargetId);
 
-    const remaining = updatedContracts.filter(
-      (contract) => contract.id !== deleteTargetId && contract.status !== '삭제됨'
-    );
-
-    setSelectedContractId(remaining[0]?.id ?? 0);
-    setDeleteTargetId(null);
-    setShowDeleteModal(false);
+      setContracts(remaining);
+      setSelectedContractId(remaining[0]?.id ?? null);
+      setShowDeleteModal(false);
+      setDeleteTargetId(null);
+      setShowAllContracts(false);
+    } catch {
+      setUploadErrorMessage('계약서 삭제에 실패했어요. 잠시 후 다시 시도해주세요.');
+      setShowUploadErrorModal(true);
+    } finally {
+      setDeleting(false);
+    }
   };
 
-  const handleAnalyze = () => {
+  const handleAnalyze = async () => {
     if (!selectedContract || selectedContract.status === '삭제됨') return;
 
-    setContracts((prev) =>
-      prev.map((contract) =>
-        contract.id === selectedContract.id
-          ? {
-              ...contract,
-              status: '분석 완료',
-              updatedAt: '방금 전',
-              summary:
-                analysisNote.trim() ||
-                '독소조항, 책임 범위, 해지 조항, 대금 지급 조건을 중심으로 분석 요청이 완료되었어요.',
-            }
-          : contract
-      )
-    );
+    try {
+      setAnalyzing(true);
 
-    setAnalysisNote('');
-    setAnalysisOpen(true);
+      await client.post(`/api/v1/contracts/${selectedContract.id}/request-analysis`);
+
+      navigate(`/loading/${selectedContract.id}`);
+    } catch {
+      setUploadErrorMessage('분석 요청에 실패했어요. 이미 분석 중인 계약서일 수 있어요.');
+      setShowUploadErrorModal(true);
+    } finally {
+      setAnalyzing(false);
+    }
   };
 
   return (
@@ -414,7 +625,7 @@ export default function ContractManagementScreen() {
             <div className="mt-3.5 grid gap-3.5 sm:mt-4 sm:gap-4">
               <SectionCard
                 title="계약서 업로드"
-                subtitle="PDF 파일 업로드"
+                subtitle="PDF, TXT, 이미지 파일 업로드"
                 open={uploadOpen}
                 onToggle={() => setUploadOpen((prev) => !prev)}
               >
@@ -430,7 +641,7 @@ export default function ContractManagementScreen() {
                           새 계약서 업로드
                         </p>
                         <p className="mt-1 text-[11px] leading-5 text-slate-500 sm:text-[12px]">
-                          업로드 후 목록 조회, 상세 확인, 삭제, 분석 요청까지 바로 이어서 진행할 수 있어요.
+                          PDF, TXT, 이미지 파일을 여러 개 선택해서 업로드할 수 있어요.
                         </p>
                       </div>
                     </div>
@@ -440,7 +651,8 @@ export default function ContractManagementScreen() {
                       파일 선택
                       <input
                         type="file"
-                        accept=".pdf"
+                        multiple
+                        accept=".pdf,.txt,.png,.jpg,.jpeg,.webp,image/*,text/plain,application/pdf"
                         className="hidden"
                         onChange={handleSelectFile}
                       />
@@ -449,17 +661,46 @@ export default function ContractManagementScreen() {
 
                   <div className="mt-3 rounded-xl bg-white p-3">
                     <p className="text-[10px] text-slate-400">선택된 파일</p>
-                    <p className="mt-1 break-all text-[12px] font-medium text-slate-700">
-                      {selectedFileName || '아직 선택된 파일이 없어요.'}
-                    </p>
+
+                    <div className="mt-2 space-y-1.5">
+                      {selectedFiles.length > 0 ? (
+                        selectedFiles.map((file, index) => (
+                          <div
+                            key={`${file.name}-${file.size}-${file.lastModified}`}
+                            className="flex items-center justify-between gap-2 rounded-lg bg-[#F8FAFF] px-3 py-2"
+                          >
+                            <div className="min-w-0">
+                              <p className="break-all text-[12px] font-medium text-slate-700">
+                                {file.name}
+                              </p>
+                              <p className="mt-0.5 text-[10px] text-slate-400">
+                                {formatFileSize(file.size)}
+                              </p>
+                            </div>
+
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveSelectedFile(index)}
+                              className="shrink-0 text-[11px] font-medium text-slate-400 transition hover:text-rose-500"
+                            >
+                              삭제
+                            </button>
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-[12px] font-medium text-slate-700">
+                          아직 선택된 파일이 없어요.
+                        </p>
+                      )}
+                    </div>
 
                     <button
                       type="button"
                       onClick={handleUpload}
-                      disabled={!selectedFileName}
+                      disabled={selectedFiles.length === 0 || uploading}
                       className="mt-3 inline-flex h-10 w-full items-center justify-center rounded-xl bg-[#6C80DD] px-4 text-[12px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
                     >
-                      업로드 실행
+                      {uploading ? '업로드 중...' : '업로드 실행'}
                     </button>
                   </div>
                 </div>
@@ -468,7 +709,13 @@ export default function ContractManagementScreen() {
               <div className="mx-auto grid w-full max-w-[920px] gap-3 lg:grid-cols-[0.92fr_1.08fr] lg:gap-4">
                 <SectionCard
                   title="계약서 목록 조회"
-                  subtitle={`${visibleContracts.length}개 계약서`}
+                  subtitle={
+                    loading
+                      ? '불러오는 중'
+                      : showAllContracts
+                      ? `${visibleContracts.length}개 전체 표시`
+                      : `${visibleContracts.length}개 중 ${Math.min(visibleContracts.length, 5)}개 표시`
+                  }
                   open={listOpen}
                   onToggle={() => setListOpen((prev) => !prev)}
                 >
@@ -483,20 +730,39 @@ export default function ContractManagementScreen() {
                   </div>
 
                   <div className="mt-3 space-y-2.5">
-                    {visibleContracts.map((contract) => (
-                      <ContractListItem
-                        key={contract.id}
-                        contract={contract}
-                        isActive={selectedContractId === contract.id}
-                        onClick={() => setSelectedContractId(contract.id)}
-                        onDelete={() => handleOpenDeleteModal(contract.id)}
-                      />
-                    ))}
+                    {loading && (
+                      <div className="rounded-[16px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center text-[12px] text-slate-400 sm:text-[13px]">
+                        계약서 목록을 불러오는 중이에요.
+                      </div>
+                    )}
 
-                    {visibleContracts.length === 0 && (
+                    {!loading &&
+                      displayedContracts.map((contract) => (
+                        <ContractListItem
+                          key={contract.id}
+                          contract={contract}
+                          isActive={selectedContractId === contract.id}
+                          onClick={() => setSelectedContractId(contract.id)}
+                          onDelete={() => handleOpenDeleteModal(contract.id)}
+                        />
+                      ))}
+
+                    {!loading && visibleContracts.length === 0 && (
                       <div className="rounded-[16px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center text-[12px] text-slate-400 sm:text-[13px]">
                         조회되는 계약서가 없어요.
                       </div>
+                    )}
+
+                    {!loading && visibleContracts.length > 5 && (
+                      <button
+                        type="button"
+                        onClick={() => setShowAllContracts((prev) => !prev)}
+                        className="mt-3 inline-flex h-10 w-full items-center justify-center rounded-xl bg-[#EEF2F9] px-4 text-[12px] font-semibold text-[#5F75B1] transition hover:opacity-90"
+                      >
+                        {showAllContracts
+                          ? '접기'
+                          : `더 보기 (${visibleContracts.length - 5}개 더)`}
+                      </button>
                     )}
                   </div>
                 </SectionCard>
@@ -569,27 +835,41 @@ export default function ContractManagementScreen() {
                         </p>
                       </div>
 
-                      {selectedContract.status !== '삭제됨' && (
-                        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
-                          <button
-                            type="button"
-                            onClick={handleAnalyze}
-                            className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl bg-[#6C80DD] px-4 text-[12px] font-semibold text-white transition hover:opacity-90 sm:w-auto"
-                          >
-                            <BarChart3 className="h-4 w-4" />
-                            분석 요청
-                          </button>
+                      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
+                        <button
+                          type="button"
+                          onClick={handleAnalyze}
+                          disabled={analyzing}
+                          style={{
+                            height: '40px',
+                            padding: '0 16px',
+                            borderRadius: '12px',
+                            backgroundColor: analyzing ? '#AAB6E8' : '#6C80DD',
+                            color: '#FFFFFF',
+                            fontSize: '12px',
+                            fontWeight: 700,
+                            border: 'none',
+                            cursor: analyzing ? 'not-allowed' : 'pointer',
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: '8px',
+                            boxShadow: '0 8px 18px rgba(108, 128, 221, 0.18)',
+                          }}
+                        >
+                          <BarChart3 size={16} />
+                          {analyzing ? '요청 중...' : '분석 요청'}
+                        </button>
 
-                          <button
-                            type="button"
-                            onClick={() => handleOpenDeleteModal(selectedContract.id)}
-                            className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 text-[12px] font-medium text-slate-500 transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-500 sm:w-auto"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                            계약서 삭제
-                          </button>
-                        </div>
-                      )}
+                        <button
+                          type="button"
+                          onClick={() => handleOpenDeleteModal(selectedContract.id)}
+                          className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 text-[12px] font-medium text-slate-500 transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-500 sm:w-auto"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          계약서 삭제
+                        </button>
+                      </div>
                     </>
                   ) : (
                     <div className="flex min-h-[220px] items-center justify-center rounded-[16px] border border-dashed border-slate-200 bg-slate-50 text-center text-[12px] text-slate-400 sm:text-[13px]">
@@ -601,37 +881,60 @@ export default function ContractManagementScreen() {
 
               <SectionCard
                 title="계약서 분석 요청"
-                subtitle="선택한 계약서에 분석 요청 보내기"
+                subtitle="선택한 계약서 분석 시작"
                 open={analysisOpen}
                 onToggle={() => setAnalysisOpen((prev) => !prev)}
               >
                 <div className="mx-auto w-full max-w-[900px] rounded-[16px] border border-slate-100 bg-white p-3">
-                  <div className="flex items-center gap-2">
-                    <BarChart3 className="h-4 w-4 text-[#6C80DD]" />
-                    <p className="text-[12px] font-semibold text-slate-900 sm:text-[13px]">
-                      분석 메모
-                    </p>
-                  </div>
+                  {selectedContract ? (
+                    <>
+                      <div className="flex items-center gap-2">
+                        <BarChart3 className="h-4 w-4 text-[#6C80DD]" />
+                        <p className="text-[12px] font-semibold text-slate-900 sm:text-[13px]">
+                          선택한 계약서 분석 요청
+                        </p>
+                      </div>
 
-                  <p className="mt-1 text-[11px] leading-5 text-slate-500 sm:text-[12px]">
-                    독소조항, 해지 조항, 책임 범위, 손해배상, 대금 지급 조건 등 확인이 필요한 내용을 적어둘 수 있어요.
-                  </p>
+                      <p className="mt-1 text-[11px] leading-5 text-slate-500 sm:text-[12px]">
+                        아래 계약서에 대해 AI 분석을 시작합니다. 요청 후 로딩 화면에서 진행 상태를 확인할 수 있어요.
+                      </p>
 
-                  <textarea
-                    value={analysisNote}
-                    onChange={(e) => setAnalysisNote(e.target.value)}
-                    placeholder="예: 해지 조항과 위약금 조항이 과도한지 분석해줘."
-                    className="mt-3 min-h-[92px] w-full resize-none rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-[12px] outline-none transition focus:border-[#D8E0F5]"
-                  />
+                      <div className="mt-3 rounded-xl bg-[#F8FAFF] px-3 py-3">
+                        <p className="text-[10px] text-slate-400">선택한 계약서</p>
+                        <p className="mt-1 break-all text-[13px] font-semibold text-slate-800">
+                          {selectedContract.title}
+                        </p>
+                        <p className="mt-1 break-all text-[11px] text-slate-500">
+                          {selectedContract.fileName}
+                        </p>
+                      </div>
 
-                  <button
-                    type="button"
-                    onClick={handleAnalyze}
-                    disabled={!selectedContract || selectedContract.status === '삭제됨'}
-                    className="mt-3 inline-flex h-10 w-full items-center justify-center rounded-xl bg-[#6C80DD] px-4 text-[12px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-                  >
-                    분석 요청 실행
-                  </button>
+                      <button
+                        type="button"
+                        onClick={handleAnalyze}
+                        disabled={analyzing}
+                        style={{
+                          width: '100%',
+                          height: '44px',
+                          marginTop: '16px',
+                          borderRadius: '12px',
+                          backgroundColor: analyzing ? '#AAB6E8' : '#6C80DD',
+                          color: '#FFFFFF',
+                          fontSize: '13px',
+                          fontWeight: 700,
+                          border: 'none',
+                          cursor: analyzing ? 'not-allowed' : 'pointer',
+                          boxShadow: '0 8px 18px rgba(108, 128, 221, 0.22)',
+                        }}
+                      >
+                        {analyzing ? '분석 요청 중...' : '선택한 계약서 분석 요청'}
+                      </button>
+                    </>
+                  ) : (
+                    <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center text-[12px] text-slate-400">
+                      먼저 계약서를 선택해주세요.
+                    </div>
+                  )}
                 </div>
               </SectionCard>
 
@@ -643,10 +946,7 @@ export default function ContractManagementScreen() {
               >
                 <div className="mx-auto w-full max-w-[900px] space-y-2.5">
                   {deletedContracts.map((contract) => (
-                    <div
-                      key={contract.id}
-                      className="rounded-[14px] border border-slate-100 bg-white p-3"
-                    >
+                    <div key={contract.id} className="rounded-[14px] border border-slate-100 bg-white p-3">
                       <div className="flex items-start gap-3">
                         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-rose-50">
                           <Trash2 className="h-4 w-4 text-rose-500" />
@@ -720,13 +1020,14 @@ export default function ContractManagementScreen() {
               <button
                 type="button"
                 onClick={handleConfirmDeleteContract}
+                disabled={deleting}
                 style={{
                   backgroundColor: '#EEF2FF',
                   color: '#4C63D2',
                 }}
-                className="flex-1 rounded-xl py-2.5 text-[13px] font-semibold shadow-sm transition hover:opacity-90"
+                className="flex-1 rounded-xl py-2.5 text-[13px] font-semibold shadow-sm transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                삭제
+                {deleting ? '삭제 중...' : '삭제'}
               </button>
             </div>
           </div>
@@ -738,9 +1039,7 @@ export default function ContractManagementScreen() {
           <div className="w-full max-w-[360px] rounded-2xl bg-white p-5 shadow-lg">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-[16px] font-semibold text-slate-900">
-                  업로드 실패
-                </h2>
+                <h2 className="text-[16px] font-semibold text-slate-900">알림</h2>
                 <p className="mt-2 text-[13px] leading-6 text-slate-500">
                   {uploadErrorMessage}
                 </p>

--- a/src/app/screens/Home.tsx
+++ b/src/app/screens/Home.tsx
@@ -34,12 +34,15 @@ export function Home() {
     try {
       setIsLoading(true);
 
-      // 1. 내 정보 가져오기
-      const userRes = await client.get('/api/v1/auth/me');
-      const userData = userRes.data;
-
-      if (userData) {
-        setNickname(userData.nickname || userData.user?.email || '사용자');
+      // 1. 내 정보 가져오기 (실패해도 계약서 목록 조회는 계속)
+      try {
+        const userRes = await client.get('/api/v1/auth/me');
+        const userData = userRes.data;
+        if (userData) {
+          setNickname(userData.nickname || userData.user?.email || '사용자');
+        }
+      } catch (error) {
+        console.error('사용자 정보 로드 실패:', error);
       }
 
       // 2. 계약서 목록 가져오기
@@ -64,7 +67,7 @@ export function Home() {
 
       setContracts(parsedContracts);
     } catch (error: any) {
-      console.error('데이터 로드 실패:', error);
+      console.error('계약서 목록 로드 실패:', error);
       setContracts([]);
     } finally {
       setIsLoading(false);
@@ -74,7 +77,7 @@ export function Home() {
   useEffect(() => {
     fetchData();
     fetchUnreadCount();
-  }, [fetchData, location.pathname, location.state]);
+  }, [fetchData, location.pathname]);
 
   const normalizeRiskLevel = (value: unknown) => {
     const level = String(value ?? '').toLowerCase();
@@ -138,7 +141,7 @@ export function Home() {
     : contracts.slice(0, 3);
 
   const completedContracts = contracts.filter(
-    (contract) => contract.status === 'completed'
+    (contract) => contract.status === 'COMPLETED'
   );
 
   const averageSafetyScore =
@@ -329,12 +332,12 @@ export function Home() {
                             <div className="mt-3 flex items-center gap-2">
                               <span
                                 className={`rounded-full px-2.5 py-1 text-xs font-medium ${
-                                  doc.status === 'completed'
+                                  doc.status === 'COMPLETED'
                                     ? 'bg-emerald-50 text-emerald-600'
                                     : 'bg-blue-50 text-blue-600'
                                 }`}
                               >
-                                {doc.status === 'completed'
+                                {doc.status === 'COMPLETED'
                                   ? '분석 완료'
                                   : '분석 중'}
                               </span>

--- a/src/app/screens/Loading.tsx
+++ b/src/app/screens/Loading.tsx
@@ -193,7 +193,7 @@ export function Loading() {
       }, 3000);
     };
 
-    const startAnalysis = () => {
+    const startLoading = () => {
       if (!contractId) {
         setErrorMessage('계약서 ID를 찾을 수 없어요.');
         setShowFailModal(true);
@@ -201,49 +201,12 @@ export function Loading() {
       }
 
       setProgress(20);
-
       startFakeProgress();
       startStepTimers();
       startPolling();
-
-      client
-        .post(
-          `/api/v1/contracts/${contractId}/analyze`,
-          {},
-          {
-            timeout: 300000,
-          },
-        )
-        .catch((err: any) => {
-          if (err?.response?.status === 409) {
-            console.log('이미 분석 중입니다.');
-            return;
-          }
-
-          const status = err?.response?.status;
-
-          if (status === 401 || status === 403) {
-            addBotMessage('인증 상태를 다시 확인하고 있어요. 분석은 계속 진행 중입니다.');
-            return;
-          }
-
-          stopPolling();
-
-          if (err?.code === 'ECONNABORTED') {
-            setErrorMessage('분석 요청 시간이 초과되었어요. 잠시 후 다시 시도해주세요.');
-          } else {
-            setErrorMessage(
-              err?.response?.data?.detail ??
-                '분석 요청 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.',
-            );
-          }
-
-          addBotMessage('분석 요청 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.');
-          setShowFailModal(true);
-        });
     };
 
-    startAnalysis();
+    startLoading();
 
     return () => {
       stopPolling();

--- a/src/app/screens/Login.tsx
+++ b/src/app/screens/Login.tsx
@@ -15,12 +15,14 @@ export function Login() {
   const [isLoginErrorOpen, setIsLoginErrorOpen] = useState(false);
   const [isFindPasswordOpen, setIsFindPasswordOpen] = useState(false);
   const [findPasswordEmail, setFindPasswordEmail] = useState('');
+  const [isSendingReset, setIsSendingReset] = useState(false);
+  const [resetMessage, setResetMessage] = useState('');
+  const [resetError, setResetError] = useState('');
 
   const handleBack = () => {
     navigate('/');
   };
 
-    // 35번째 줄부터 수정 시작
   const handleLogin = async () => {
     if (!email.trim() || !password.trim()) {
       setIsLoginErrorOpen(true);
@@ -30,47 +32,15 @@ export function Login() {
     try {
       setIsLoading(true);
 
-      // 환경 변수 설정 (빨간 줄 방지를 위해 @ts-ignore 추가)
-      // 46번째 줄 근처
-      // @ts-ignore
-      const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
+      const { data } = await client.post('/api/v1/auth/login/json', { email, password });
+      const token = data.accessToken || data.access_token;
 
-      // 49번째 줄 근처
-      // 기존 ngrok 주소 대신 백틱(`)과 ${apiUrl}을 사용했는지 확인!
-      const response = await fetch(`${apiUrl}/api/v1/auth/login/json`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          email,
-          password,
-        }),
-      });
-
-      if (!response.ok) {
+      if (token) {
+        localStorage.setItem('accessToken', token);
+        navigate('/home');
+      } else {
         setIsLoginErrorOpen(true);
-        return;
       }
-
-      // Login.tsx 의 handleLogin 함수 안쪽
-        // Login.tsx 의 handleLogin 함수 내부 수정
-    const data = await response.json();
-    console.log("로그인 서버 응답 전체 데이터:", data); // 👈 여기서 정확한 이름을 눈으로 확인 가능!
-
-    // 둘 중 하나라도 있으면 저장하도록 '||' (OR 연산자) 사용
-    const token = data.accessToken || data.access_token;
-
-    if (token) {
-      localStorage.setItem('accessToken', token);
-      console.log("토큰 저장 성공! ");
-      navigate('/home'); //토큰이 있을 때만 홈으로 이동
-    } else {
-      console.error("토큰을 찾을 수 없습니다.");
-      setIsLoginErrorOpen(true); //토큰이 없으면 로그인 실패 팝업 띄우기
-    }
-
-    navigate('/home');
     } catch (error) {
       console.error(error);
       setIsLoginErrorOpen(true);
@@ -83,12 +53,36 @@ export function Login() {
     navigate('/signup');
   };
 
-  const handleFindPasswordSubmit = () => {
+  const handleFindPasswordSubmit = async () => {
     if (!findPasswordEmail.trim()) return;
 
-    alert('비밀번호 재설정 링크가 이메일로 전송되었습니다.');
-    setFindPasswordEmail('');
+    try {
+      setIsSendingReset(true);
+      setResetError('');
+      setResetMessage('');
+
+      await client.post('/api/v1/auth/password-reset/request', {
+        email: findPasswordEmail.trim(),
+      });
+
+      setResetMessage('비밀번호 재설정 링크가 이메일로 전송되었습니다. 메일함을 확인해주세요.');
+      setFindPasswordEmail('');
+    } catch (error: any) {
+      setResetError(
+        error?.response?.data?.detail ||
+        error?.response?.data?.message ||
+        '이메일 전송에 실패했습니다. 가입된 이메일인지 확인해주세요.'
+      );
+    } finally {
+      setIsSendingReset(false);
+    }
+  };
+
+  const handleCloseFindPassword = () => {
     setIsFindPasswordOpen(false);
+    setFindPasswordEmail('');
+    setResetMessage('');
+    setResetError('');
   };
 
   return (
@@ -316,7 +310,7 @@ export function Login() {
 
               <button
                 type="button"
-                onClick={() => setIsFindPasswordOpen(false)}
+                onClick={handleCloseFindPassword}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
                 aria-label="닫기"
               >
@@ -333,29 +327,44 @@ export function Login() {
                 placeholder="example@email.com"
                 value={findPasswordEmail}
                 onChange={(e) => setFindPasswordEmail(e.target.value)}
-                className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-[#EEF3FF] px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8]"
+                disabled={isSendingReset || !!resetMessage}
+                className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-[#EEF3FF] px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] disabled:cursor-not-allowed disabled:opacity-60"
               />
             </div>
 
-            <button
-              type="button"
-              onClick={handleFindPasswordSubmit}
-              className="mt-6 h-12 w-full rounded-[16px] text-[15px] font-semibold text-white transition-all hover:-translate-y-0.5"
-              style={{
-                background:
-                  'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
-                boxShadow: '0 14px 30px rgba(102,122,242,0.24)',
-              }}
-            >
-              재설정 링크 보내기
-            </button>
+            {resetMessage && (
+              <p className="mt-3 rounded-[14px] bg-[#EEF3FF] px-4 py-3 text-left text-[13px] font-medium leading-5 text-[#667AF2]">
+                {resetMessage}
+              </p>
+            )}
+
+            {resetError && (
+              <p className="mt-3 rounded-[14px] bg-red-50 px-4 py-3 text-left text-[13px] font-medium leading-5 text-red-500">
+                {resetError}
+              </p>
+            )}
+
+            {!resetMessage && (
+              <button
+                type="button"
+                onClick={handleFindPasswordSubmit}
+                disabled={isSendingReset || !findPasswordEmail.trim()}
+                className="mt-6 h-12 w-full rounded-[16px] text-[15px] font-semibold text-white transition-all hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60"
+                style={{
+                  background: 'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
+                  boxShadow: '0 14px 30px rgba(102,122,242,0.24)',
+                }}
+              >
+                {isSendingReset ? '전송 중...' : '재설정 링크 보내기'}
+              </button>
+            )}
 
             <button
               type="button"
-              onClick={() => setIsFindPasswordOpen(false)}
+              onClick={handleCloseFindPassword}
               className="mt-3 h-11 w-full rounded-[16px] text-[14px] font-semibold text-slate-400 transition-colors hover:bg-slate-50 hover:text-slate-600"
             >
-              취소
+              {resetMessage ? '닫기' : '취소'}
             </button>
           </div>
         </div>

--- a/src/app/screens/SignUp.tsx
+++ b/src/app/screens/SignUp.tsx
@@ -1,7 +1,7 @@
 // SignUp.tsx
-import { useState } from 'react';
+import { useEffect, useState, type ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, X } from 'lucide-react';
+import { ArrowLeft, X, Mail, ShieldCheck } from 'lucide-react';
 import client from '../../api/client';
 
 export function SignUp() {
@@ -14,9 +14,39 @@ export function SignUp() {
   const [isTermsChecked, setIsTermsChecked] = useState(false);
   const [isMarketingChecked, setIsMarketingChecked] = useState(false);
 
+  const [verificationCode, setVerificationCode] = useState('');
+  const [verificationRequested, setVerificationRequested] = useState(false);
+  const [emailVerified, setEmailVerified] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+  const [expireSeconds, setExpireSeconds] = useState(600);
+  const [emailMessage, setEmailMessage] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [isRequestingCode, setIsRequestingCode] = useState(false);
+  const [isConfirmingCode, setIsConfirmingCode] = useState(false);
+
   const [isSignUpSuccessOpen, setIsSignUpSuccessOpen] = useState(false);
   const [isSignUpErrorOpen, setIsSignUpErrorOpen] = useState(false);
   const [isTermsRequiredOpen, setIsTermsRequiredOpen] = useState(false);
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+
+    const timer = setInterval(() => {
+      setCooldown((prev) => Math.max(prev - 1, 0));
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [cooldown]);
+
+  useEffect(() => {
+    if (!verificationRequested || emailVerified || expireSeconds <= 0) return;
+
+    const timer = setInterval(() => {
+      setExpireSeconds((prev) => Math.max(prev - 1, 0));
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [verificationRequested, emailVerified, expireSeconds]);
 
   const handleBack = () => {
     navigate('/login');
@@ -26,7 +56,103 @@ export function SignUp() {
     navigate('/login');
   };
 
+  const formatTime = (seconds: number) => {
+    const min = Math.floor(seconds / 60);
+    const sec = seconds % 60;
+
+    return `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+  };
+
+  const getErrorMessage = (error: any, fallback: string) => {
+    return (
+      error?.response?.data?.detail ||
+      error?.response?.data?.message ||
+      fallback
+    );
+  };
+
+  const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    setEmail(value);
+
+    if (emailVerified || verificationRequested) {
+      setEmailVerified(false);
+      setVerificationRequested(false);
+      setVerificationCode('');
+      setExpireSeconds(600);
+      setCooldown(0);
+      setEmailMessage('');
+      setEmailError('이메일이 변경되어 다시 인증이 필요합니다.');
+    }
+  };
+
+  const handleRequestVerification = async () => {
+    if (!email.trim()) {
+      setEmailError('이메일을 입력해주세요.');
+      return;
+    }
+
+    try {
+      setIsRequestingCode(true);
+      setEmailError('');
+      setEmailMessage('');
+
+      await client.post('/api/v1/auth/email-verification/request', {
+        email: email.trim(),
+      });
+
+      setVerificationRequested(true);
+      setEmailVerified(false);
+      setVerificationCode('');
+      setCooldown(60);
+      setExpireSeconds(600);
+
+      setEmailMessage('인증 코드가 이메일로 전송되었습니다. 메일함을 확인해주세요.');
+    } catch (error: any) {
+      setEmailError(getErrorMessage(error, '인증 코드 요청에 실패했습니다.'));
+    } finally {
+      setIsRequestingCode(false);
+    }
+  };
+
+  const handleConfirmVerification = async () => {
+    if (!verificationCode.trim()) {
+      setEmailError('인증 코드를 입력해주세요.');
+      return;
+    }
+
+    if (expireSeconds <= 0) {
+      setEmailError('만료된 코드입니다. 인증 코드를 다시 요청해주세요.');
+      return;
+    }
+
+    try {
+      setIsConfirmingCode(true);
+      setEmailError('');
+      setEmailMessage('');
+
+      await client.post('/api/v1/auth/email-verification/confirm', {
+        email: email.trim(),
+        code: verificationCode.trim(),
+      });
+
+      setEmailVerified(true);
+      setEmailMessage('이메일 인증이 완료되었습니다.');
+    } catch (error: any) {
+      setEmailVerified(false);
+      setEmailError(getErrorMessage(error, '인증 코드 확인에 실패했습니다.'));
+    } finally {
+      setIsConfirmingCode(false);
+    }
+  };
+
   const handleSignUp = async () => {
+    if (!emailVerified) {
+      setEmailError('이메일 인증이 필요합니다.');
+      return;
+    }
+
     if (!isTermsChecked) {
       setIsTermsRequiredOpen(true);
       return;
@@ -43,41 +169,17 @@ export function SignUp() {
       return;
     }
 
-      try {
-    // 직접 적혀있던 ngrok 주소를 지우고 환경 변수를 사용하도록 변경합니다.
-    // @ts-ignore
-const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
-      
-      const response = await fetch(
-        `${apiUrl}/api/v1/auth/signup`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            // 로컬 연결 시에는 ngrok 경고 헤더가 필요 없지만 남겨둬도 무방합니다.
-          },
-          body: JSON.stringify({
-            email: email.trim(),
-            nickname: nickname.trim(),
-            password,
-            password_confirm: passwordCheck,
-          }),
-        }
-    );
-
-      const data = await response.json().catch(() => null);
-
-      console.log('회원가입 상태:', response.status);
-      console.log('회원가입 응답:', data);
-
-      if (!response.ok) {
-        setIsSignUpErrorOpen(true);
-        return;
-      }
+    try {
+      await client.post('/api/v1/auth/signup', {
+        email: email.trim(),
+        nickname: nickname.trim(),
+        password,
+        password_confirm: passwordCheck,
+      });
 
       setIsSignUpSuccessOpen(true);
-    } catch (error) {
-      console.error(error);
+    } catch (error: any) {
+      setEmailError(getErrorMessage(error, '회원가입에 실패했습니다.'));
       setIsSignUpErrorOpen(true);
     }
   };
@@ -135,17 +237,133 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
                   boxShadow: '0 30px 70px rgba(15,23,42,0.10)',
                 }}
               >
-                <div>
+                <div className="rounded-[24px] border border-[#E6ECFF] bg-white/72 p-4 sm:p-5">
+                  <div className="mb-4 flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="flex h-10 w-10 items-center justify-center rounded-2xl text-white shadow-[0_12px_26px_rgba(102,122,242,0.22)]"
+                        style={{
+                          background:
+                            'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
+                        }}
+                      >
+                        <Mail size={19} strokeWidth={2.3} />
+                      </div>
+
+                      <div className="text-left">
+                        <p className="text-[13px] font-semibold text-[#667AF2]">
+                          STEP 1
+                        </p>
+                        <h2 className="text-[16px] font-bold tracking-[-0.03em] text-slate-900 sm:text-[17px]">
+                          이메일 인증
+                        </h2>
+                      </div>
+                    </div>
+
+                    {emailVerified && (
+                      <div className="inline-flex items-center gap-1.5 rounded-full bg-[#EEF3FF] px-3 py-1.5 text-[12px] font-semibold text-[#667AF2]">
+                        <ShieldCheck size={14} />
+                        인증 완료
+                      </div>
+                    )}
+                  </div>
+
                   <label className="mb-3 block text-left text-[14px] font-semibold text-slate-800 sm:text-[15px]">
                     이메일
                   </label>
-                  <input
-                    type="email"
-                    placeholder="example@email.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
-                  />
+
+                  <div className="flex gap-2">
+                    <input
+                      type="email"
+                      placeholder="example@email.com"
+                      value={email}
+                      onChange={handleEmailChange}
+                      disabled={emailVerified}
+                      className="h-[52px] min-w-0 flex-1 rounded-[16px] border border-slate-200/80 bg-white px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] disabled:cursor-not-allowed disabled:bg-[#F8FAFF] disabled:text-slate-500 sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
+                    />
+
+                    <button
+                      type="button"
+                      onClick={handleRequestVerification}
+                      disabled={cooldown > 0 || isRequestingCode || emailVerified}
+                      className="h-[52px] w-[132px] flex-shrink-0 whitespace-nowrap rounded-[16px] px-4 text-[12px] font-semibold text-white transition-all hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 sm:h-[56px] sm:w-[148px] sm:rounded-[18px] sm:px-5 sm:text-[13px]"
+                      style={{
+                        background:
+                          'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
+                        boxShadow: '0 12px 26px rgba(102,122,242,0.22)',
+                      }}
+                    >
+                      {emailVerified
+                        ? '인증 완료'
+                        : isRequestingCode
+                          ? '발송 중'
+                          : cooldown > 0
+                            ? `${cooldown}초 후`
+                            : '인증 코드 받기'}
+                    </button>
+                  </div>
+
+                  {verificationRequested && !emailVerified && (
+                    <div className="mt-4 rounded-[20px] border border-slate-200/80 bg-[#F8FAFF] p-3 sm:p-4">
+                      <div className="flex gap-2">
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          maxLength={6}
+                          placeholder="6자리 인증 코드"
+                          value={verificationCode}
+                          onChange={(e) => setVerificationCode(e.target.value)}
+                          className="h-[52px] min-w-0 flex-1 rounded-[16px] border border-slate-200/80 bg-white px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
+                        />
+
+                        <button
+                          type="button"
+                          onClick={handleConfirmVerification}
+                          disabled={isConfirmingCode || expireSeconds <= 0}
+                          className="h-[52px] w-[128px] flex-shrink-0 whitespace-nowrap rounded-[16px] px-4 text-[13px] font-semibold text-white transition-all hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 sm:h-[56px] sm:w-[140px] sm:rounded-[18px] sm:px-5 sm:text-[14px]"
+                            style={{
+                            background: 'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
+                            boxShadow: '0 12px 26px rgba(102,122,242,0.22)',
+                          }}
+                        >
+                          {isConfirmingCode ? '확인 중' : '인증 확인'}
+                        </button>
+                      </div>
+
+                      <div className="mt-3 flex items-center justify-between gap-3">
+                        <p className="text-left text-[13px] text-slate-500">
+                          인증 코드 유효시간{' '}
+                          <span className="font-semibold text-slate-700">
+                            {formatTime(expireSeconds)}
+                          </span>
+                        </p>
+
+                        <span className="whitespace-nowrap text-[13px] font-medium text-slate-400">
+                          5회 실패 시 재발급 필요
+                        </span>
+                      </div>
+                    </div>
+                  )}
+
+                  {emailMessage && (
+                    <p className="mt-3 rounded-[16px] bg-[#EEF3FF] px-4 py-3 text-left text-[13px] font-medium leading-5 text-[#667AF2]">
+                      {emailMessage}
+                    </p>
+                  )}
+
+                  {emailError && (
+                    <p className="mt-3 rounded-[16px] bg-red-50 px-4 py-3 text-left text-[13px] font-medium leading-5 text-red-500">
+                      {emailError}
+                    </p>
+                  )}
+                </div>
+
+                <div className="mt-5 flex items-center gap-3 sm:mt-6">
+                  <div className="h-px flex-1 bg-slate-200" />
+                  <span className="rounded-full bg-slate-50 px-3 py-1 text-[12px] font-medium text-slate-400">
+                    STEP 2
+                  </span>
+                  <div className="h-px flex-1 bg-slate-200" />
                 </div>
 
                 <div className="mt-5 sm:mt-6">
@@ -157,7 +375,8 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
                     placeholder="사용할 닉네임을 입력하세요"
                     value={nickname}
                     onChange={(e) => setNickname(e.target.value)}
-                    className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
+                    disabled={!emailVerified}
+                    className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   />
                 </div>
 
@@ -170,7 +389,8 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
                     placeholder="8자 이상 입력하세요"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
-                    className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
+                    disabled={!emailVerified}
+                    className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   />
                 </div>
 
@@ -183,7 +403,8 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
                     placeholder="비밀번호를 다시 입력하세요"
                     value={passwordCheck}
                     onChange={(e) => setPasswordCheck(e.target.value)}
-                    className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
+                    disabled={!emailVerified}
+                    className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   />
                 </div>
 
@@ -193,7 +414,8 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
                       type="checkbox"
                       checked={isTermsChecked}
                       onChange={(e) => setIsTermsChecked(e.target.checked)}
-                      className="mt-1 h-4 w-4 rounded border-slate-300 accent-[#6C80DD]"
+                      disabled={!emailVerified}
+                      className="mt-1 h-4 w-4 rounded border-slate-300 accent-[#6C80DD] disabled:cursor-not-allowed"
                     />
                     <span>서비스 이용약관 및 개인정보 처리방침에 동의합니다</span>
                   </label>
@@ -203,7 +425,8 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
                       type="checkbox"
                       checked={isMarketingChecked}
                       onChange={(e) => setIsMarketingChecked(e.target.checked)}
-                      className="mt-1 h-4 w-4 rounded border-slate-300 accent-[#6C80DD]"
+                      disabled={!emailVerified}
+                      className="mt-1 h-4 w-4 rounded border-slate-300 accent-[#6C80DD] disabled:cursor-not-allowed"
                     />
                     <span>마케팅 정보 수신에 동의합니다 (선택)</span>
                   </label>
@@ -212,7 +435,8 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
                 <button
                   type="button"
                   onClick={handleSignUp}
-                  className="mt-6 h-[54px] w-full rounded-[18px] text-[16px] font-semibold text-white transition-all hover:-translate-y-0.5 sm:mt-7 sm:h-[58px] sm:rounded-[20px] sm:text-[17px]"
+                  disabled={!emailVerified}
+                  className="mt-6 h-[54px] w-full rounded-[18px] text-[16px] font-semibold text-white transition-all hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 sm:mt-7 sm:h-[58px] sm:rounded-[20px] sm:text-[17px]"
                   style={{
                     background:
                       'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',

--- a/src/app/screens/Upload.tsx
+++ b/src/app/screens/Upload.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 
 type Message = {
+  id: string;
   role: 'bot' | 'user';
   text: string;
 };
@@ -37,10 +38,12 @@ export function Upload() {
 
   const [messages, setMessages] = useState<Message[]>([
     {
+      id: crypto.randomUUID(),
       role: 'bot',
       text: '안녕하세요! CLAIR입니다. 계약서 분석을 도와드릴게요.',
     },
     {
+      id: crypto.randomUUID(),
       role: 'bot',
       text: '분석할 계약서를 업로드해주세요. PDF, 이미지(최대 20장), 또는 텍스트 형태로 업로드할 수 있어요.',
     },
@@ -116,11 +119,8 @@ export function Upload() {
 
     setMessages((prev) => [
       ...prev,
-      { role: 'user', text: `업로드 완료: ${displayFileName}` },
-      {
-        role: 'bot',
-        text: '업로드가 완료되었어요. 이제 AI 분석을 시작해볼까요?',
-      },
+      { id: crypto.randomUUID(), role: 'user', text: `업로드 완료: ${displayFileName}` },
+      { id: crypto.randomUUID(), role: 'bot', text: '업로드가 완료되었어요. 이제 AI 분석을 시작해볼까요?' },
     ]);
   };
 
@@ -140,8 +140,8 @@ export function Upload() {
 
     setMessages((prev) => [
       ...prev,
-      { role: 'user', text: `업로드 완료: ${fileName}` },
-      { role: 'bot', text: '업로드가 완료되었어요. 이제 AI 분석을 시작해볼까요?' },
+      { id: crypto.randomUUID(), role: 'user', text: `업로드 완료: ${fileName}` },
+      { id: crypto.randomUUID(), role: 'bot', text: '업로드가 완료되었어요. 이제 AI 분석을 시작해볼까요?' },
     ]);
   };
 
@@ -157,11 +157,8 @@ export function Upload() {
 
     setMessages((prev) => [
       ...prev,
-      { role: 'user', text: '분석 시작해주세요' },
-      {
-        role: 'bot',
-        text: '좋아요. 지금 바로 분석을 시작할게요. 잠시만 기다려주세요.',
-      },
+      { id: crypto.randomUUID(), role: 'user', text: '분석 시작해주세요' },
+      { id: crypto.randomUUID(), role: 'bot', text: '좋아요. 지금 바로 분석을 시작할게요. 잠시만 기다려주세요.' },
     ]);
 
     try {
@@ -208,7 +205,7 @@ export function Upload() {
     const messageToSend = preset ?? inputMessage;
     if (!messageToSend.trim()) return;
 
-    setMessages((prev) => [...prev, { role: 'user', text: messageToSend }]);
+    setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: 'user', text: messageToSend }]);
 
     setTimeout(() => {
       let botResponse = '네, 궁금한 점을 편하게 물어보세요.';
@@ -219,17 +216,11 @@ export function Upload() {
       } else if (messageToSend.includes('결과') || messageToSend.includes('어떻게')) {
         botResponse = '분석이 끝나면 핵심 요약, 위험 요소, 계약 안정도 등을 한눈에 볼 수 있어요.';
       }
-      setMessages((prev) => [...prev, { role: 'bot', text: botResponse }]);
+      setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: 'bot', text: botResponse }]);
     }, 500);
 
     setInputMessage('');
   };
-
-  const suggestedQuestions = [
-    '계약서 분석은 얼마나 걸리나요?',
-    '어떤 위험 요소를 찾나요?',
-    '분석 결과는 어떻게 보나요?',
-  ];
 
   return (
     <div
@@ -403,8 +394,8 @@ export function Upload() {
                 {/* 챗 메시지 영역 */}
                 <div className="hidden min-h-[380px] flex-col bg-white/30 lg:flex">
                   <div className="flex-1 space-y-4 overflow-y-auto p-4 sm:p-6">
-                    {messages.map((message, index) => (
-                      <div key={index} className={`flex gap-3 ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                    {messages.map((message) => (
+                      <div key={message.id} className={`flex gap-3 ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                         {message.role === 'bot' && (
                           <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[14px] text-white" style={{ background: 'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)' }}>
                             <Bot size={16} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,13 @@ export default defineConfig({
 
   // File types to support raw imports. Never add .css, .tsx, or .ts files to this.
   assetsInclude: ['**/*.svg', '**/*.csv'],
+
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 관련 이슈
Closes #55 

## 변경 사항

개발 환경에서 CORS 정책으로 인해 API 요청이 전부 차단되던 문제를 Vite 프록시로 해결하고,
각 화면에서 발생하던 로직 버그들을 함께 수정했습니다.

### 핵심 변경

**CORS 해결**
- `vite.config.ts`에 `server.proxy` 추가 — 개발 서버에서 `/api/*` 요청을 `localhost:8000`으로 프록시
- `client.ts` BASE_URL 폴백을 `''`으로 변경하여 `VITE_API_URL` 미설정 시에도 프록시를 경유하도록 수정

**Login.tsx**
- `fetch` 직접 호출 → `client.post` 교체 (Axios 인터셉터 정상 동작)
- 로그인 성공 여부와 무관하게 실행되던 중복 `navigate('/home')` 제거
- 비밀번호 찾기 기능에 실제 API 연동 (`/api/v1/auth/password-reset/request`)

**SignUp.tsx**
- `verificationRequested` 초기값 `true` → `false` 수정 (진입 즉시 타이머 시작되던 버그)
- `fetch` 직접 호출 → `client.post` 교체

**Home.tsx**
- `/auth/me`와 계약서 목록 조회를 독립적인 try/catch로 분리
- `/auth/me` 500 오류 발생 시에도 계약서 목록이 정상 로드되도록 수정

**Loading.tsx**
- `Upload.tsx`에서 이미 호출하는 `/analyze`를 Loading 진입 시 중복 호출하던 코드 제거

**기타**
- `CLAUDE.md` 프로젝트 아키텍처 가이드 문서 추가

## 변경 유형
- [x] 버그 수정 (`fix`)
- [x] 문서 수정 (`docs`)

## 테스트 체크리스트
- [x] 로컬에서 프론트엔드 / 백엔드 동시 실행 후 로그인 정상 동작 확인
- [x] 회원가입 화면 진입 시 이메일 인증 필드 숨김 상태 확인
- [x] 홈 화면 계약서 목록 정상 로드 확인
- [x] 계약서 업로드 → 분석 → Loading 화면 이동 정상 동작 확인
- [x] 기존 기능 동작에 영향 없음 확인

## 리뷰어를 위한 참고 사항

**프록시 동작 방식**
`VITE_API_URL`을 비워두면 `client.ts`의 `baseURL`이 `''`가 되어 모든 API 요청이 상대 경로(`/api/v1/...`)로 전송됩니다.
Vite 개발 서버가 이 요청을 가로채 `localhost:8000`으로 포워딩하므로 브라우저 입장에서는 동일 출처 요청이 됩니다.
프로덕션 빌드 시에는 `VITE_API_URL`에 실제 서버 주소를 설정하면 됩니다.

**Loading.tsx analyze 중복 제거**
기존에는 `Upload.tsx`에서 `/analyze` 호출 후 `/loading/:id`로 이동하고,
`Loading.tsx` 진입 시에도 다시 `/analyze`를 호출하는 구조였습니다.
백엔드에서 이미 분석 중인 경우 409를 반환하긴 하지만, 불필요한 중복 요청을 제거했습니다.
