### PR TITLE
fix: 프로필 이미지 localStorage 저장, 유저정보 fallback, 안전점수 수정

### DIFF
--- a/src/app/screens/ContractManagementScreen.tsx
+++ b/src/app/screens/ContractManagementScreen.tsx
@@ -548,8 +548,14 @@ export default function ContractManagementScreen() {
       setShowDeleteModal(false);
       setDeleteTargetId(null);
       setShowAllContracts(false);
-    } catch {
-      setUploadErrorMessage('계약서 삭제에 실패했어요. 잠시 후 다시 시도해주세요.');
+    } catch (error: any) {
+      console.error('삭제 실패:', error?.response?.status, error?.response?.data);
+      const detail = error?.response?.data?.detail || error?.response?.data?.message;
+      setUploadErrorMessage(
+        detail
+          ? `계약서 삭제에 실패했어요: ${detail}`
+          : '계약서 삭제에 실패했어요. 잠시 후 다시 시도해주세요.'
+      );
       setShowUploadErrorModal(true);
     } finally {
       setDeleting(false);

--- a/src/app/screens/Login.tsx
+++ b/src/app/screens/Login.tsx
@@ -37,6 +37,9 @@ export function Login() {
 
       if (token) {
         localStorage.setItem('accessToken', token);
+        if (data.user) {
+          localStorage.setItem('userInfo', JSON.stringify(data.user));
+        }
         navigate('/home');
       } else {
         setIsLoginErrorOpen(true);

--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -49,6 +49,18 @@ export default function ProfileScreen() {
         setProfileImage(res.data.profile_image || res.data.profileImage || null);
       } catch (error) {
         console.error('유저 정보 불러오기 실패:', error);
+        const stored = localStorage.getItem('userInfo');
+        if (stored) {
+          const u = JSON.parse(stored);
+          setUser({
+            name: u.nickname || u.name || '사용자',
+            email: u.email || '',
+            password: '',
+            createdAt: u.created_at || u.createdAt || '',
+          });
+        }
+        const savedImage = localStorage.getItem('profileImage');
+        if (savedImage) setProfileImage(savedImage);
       }
     };
 
@@ -57,25 +69,36 @@ export default function ProfileScreen() {
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-
     if (!file) return;
 
-    const imageUrl = URL.createObjectURL(file);
-    setProfileImage(imageUrl);
+    const reader = new FileReader();
+    reader.onload = () => {
+      setProfileImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
   };
 
   const handleResetImage = () => {
     setProfileImage(null);
-
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
   };
 
   const handleSave = () => {
+    const stored = localStorage.getItem('userInfo');
+    const userInfo = stored ? JSON.parse(stored) : {};
+    userInfo.nickname = user.name;
+    localStorage.setItem('userInfo', JSON.stringify(userInfo));
+
+    if (profileImage) {
+      localStorage.setItem('profileImage', profileImage);
+    } else {
+      localStorage.removeItem('profileImage');
+    }
+
     setIsEdit(false);
     setShowSaveToast(true);
-
     setTimeout(() => {
       setShowSaveToast(false);
     }, 1800);

--- a/src/app/screens/ResultDashboard.tsx
+++ b/src/app/screens/ResultDashboard.tsx
@@ -146,7 +146,7 @@ function normalizeAnalysis(data: any): AnalysisResult {
         data?.updated_at ??
         data?.created_at,
     ),
-    safetyScore: Number(data?.analysis?.safety_score ?? calculatedScore) || 0,
+    safetyScore: Number(data?.safety_score ?? data?.analysis?.safety_score ?? calculatedScore) || 0,
     contractPeriod: getKeyInfoValue(
       keyInfo,
       ['start_date', 'end_date', 'contract_period', 'contractPeriod', 'period', 'duration', '근로계약기간', '계약기간'],

--- a/src/app/screens/SettingsScreen.tsx
+++ b/src/app/screens/SettingsScreen.tsx
@@ -151,8 +151,12 @@ export default function SettingsScreen() {
     email: '',
     role: '설정 및 관리',
   });
+  const [profileImage, setProfileImage] = useState<string | null>(null);
 
   useEffect(() => {
+    const savedImage = localStorage.getItem('profileImage');
+    if (savedImage) setProfileImage(savedImage);
+
     const fetchUserInfo = async () => {
       try {
         const res = await client.get('/api/v1/auth/me');
@@ -164,6 +168,15 @@ export default function SettingsScreen() {
         });
       } catch (error) {
         console.error('유저 정보 불러오기 실패:', error);
+        const stored = localStorage.getItem('userInfo');
+        if (stored) {
+          const u = JSON.parse(stored);
+          setProfileSummary({
+            name: u.nickname || u.name || '사용자',
+            email: u.email || '',
+            role: '설정 및 관리',
+          });
+        }
       }
     };
 
@@ -223,10 +236,14 @@ export default function SettingsScreen() {
                     onClick={() => navigate('/profile')}
                     className="flex w-full items-center gap-4 text-left sm:gap-[18px]"
                   >
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white shadow-sm sm:h-11 sm:w-11">
-                      <span className="text-sm font-semibold sm:text-base">
-                        {profileSummary.name?.charAt(0)}
-                      </span>
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white shadow-sm sm:h-11 sm:w-11">
+                      {profileImage ? (
+                        <img src={profileImage} alt="프로필" className="h-full w-full object-cover" />
+                      ) : (
+                        <span className="text-sm font-semibold sm:text-base">
+                          {profileSummary.name?.charAt(0)}
+                        </span>
+                      )}
                     </div>
 
                     <div className="min-w-0 flex-1">

--- a/src/app/screens/Upload.tsx
+++ b/src/app/screens/Upload.tsx
@@ -189,7 +189,7 @@ export function Upload() {
       }
 
       // 2. 분석 요청
-      await client.post(`/api/v1/contracts/${contractId}/analyze`);
+      await client.post(`/api/v1/contracts/${contractId}/request-analysis`);
 
       navigate(`/loading/${contractId}`);
     } catch (error: any) {


### PR DESCRIPTION
## 관련 이슈
Closes #59 

## 변경 사항

### 1. 로그인 시 유저 정보 localStorage 저장 (`Login.tsx`)
- 로그인 응답의 `data.user`를 `localStorage.userInfo`에 저장
- `/api/v1/auth/me` 500 에러 발생 시 fallback 데이터로 활용

### 2. 프로필 이미지 영구 저장 (`ProfileScreen.tsx`)
- `URL.createObjectURL()` → `FileReader.readAsDataURL()`로 변경 (base64 인코딩)
- 저장 버튼 클릭 시 이미지와 닉네임을 `localStorage`에 persist
- 페이지 재진입 시 저장된 이미지/닉네임 복원
- `/api/v1/auth/me` 실패 시 `localStorage.userInfo` fallback 적용

### 3. 설정 화면 프로필 이미지 표시 (`SettingsScreen.tsx`)
- `localStorage.profileImage`에서 프로필 이미지 로드하여 아바타에 표시
- `/api/v1/auth/me` 실패 시 `localStorage.userInfo` fallback 적용

### 4. 안전점수 표시 불일치 수정 (`ResultDashboard.tsx`)
- 백엔드 응답의 `data.safety_score` (top-level)를 우선 읽도록 수정
- 기존 코드가 `data.analysis.safety_score`만 참조하여 점수가 다르게 표시되던 문제 해결

### 5. 계약서 삭제 에러 메시지 개선 (`ContractManagementScreen.tsx`)
- 삭제 실패 시 백엔드 응답의 `detail` 메시지를 모달에 표시
- `console.error`로 HTTP 상태 코드 및 응답 데이터 로깅 추가

## 변경 유형
- [ ] 새 기능 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [ ] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 로컬에서 AI 서비스 정상 기동 확인 (`uvicorn src.api.main:app --port 8001`)
- [x] 분석 파이프라인 단계별 동작 확인
- [x] 기존 기능 동작에 영향 없음 확인

## 리뷰어를 위한 참고 사항
- `/api/v1/auth/me`가 백엔드 버그(`profile_image_path` AttributeError)로 500을 반환하는 상황에서, 로그인 시 저장한 `localStorage.userInfo`를 fallback으로 사용하는 방식으로 프론트에서 우회 처리함
- 프로필 이미지는 서버 업로드 없이 `localStorage`에 base64로 저장하는 클라이언트 전용 방식이므로, 다른 기기/브라우저에서는 공유되지 않음
- 계약서 삭제 500 에러는 백엔드 `ContractShare` 모델의 `passive_deletes` 누락이 원인 (별도 백엔드 이슈로 등록)
