### PR TITLE
fix: 리스크 조항 제목 표시 오류 수정

### DIFF
--- a/src/app/screens/ResultDashboard.tsx
+++ b/src/app/screens/ResultDashboard.tsx
@@ -116,6 +116,7 @@ function normalizeAnalysis(data: any): AnalysisResult {
   const risks: RiskItem[] = Array.isArray(data?.risk_clauses)
     ? data.risk_clauses.map((risk: any) => ({
         title:
+          risk?.title ??
           risk?.risk_type ??
           risk?.clause_number ??
           risk?.original_text?.slice?.(0, 24) ??


### PR DESCRIPTION
## Summary

- 리스크 카드 제목이 `risk_type`('payment', 'etc') 대신 `title`('상여금 지급 불확실성') 우선 표시되도록 수정

## Before / After

| 이전 | 이후 |
|------|------|
| `payment` | `상여금 지급 불확실성` |
| `etc` | `취업규칙에 대한 포괄적 동의` |

## Root cause

`normalizeAnalysis` 함수에서 `risk?.risk_type`을 `risk?.title`보다 먼저 읽어 영문 타입명이 표시됨.

## Related Issue

Closes #67

## Test plan

- [x] 결과 화면에서 리스크 카드 제목이 한국어로 표시되는지 확인