### PR TITLE
feat: 공유 페이지(SharePage) 안전점수 도넛 차트 SVG 기반 교체

### DIFF
--- a/src/app/screens/ResultDashboard.tsx
+++ b/src/app/screens/ResultDashboard.tsx
@@ -19,9 +19,11 @@ import {
   Copy,
   X,
   Link2,
+  Scale,
+  XCircle,
 } from 'lucide-react';
 
-type MessageType = 'text' | 'score' | 'summary' | 'risks';
+type MessageType = 'text' | 'score' | 'summary' | 'risks' | 'compliance';
 type Role = 'bot' | 'user';
 
 type Message = {
@@ -38,6 +40,15 @@ type RiskItem = {
   level: RiskLevel;
 };
 
+type ComplianceStatus = '위반' | '주의' | '적합' | '검토불가';
+
+type ComplianceItem = {
+  clauseId: string;
+  clauseTitle: string;
+  status: ComplianceStatus;
+  reason: string;
+};
+
 type AnalysisResult = {
   fileName: string;
   analyzedDate: string;
@@ -48,6 +59,7 @@ type AnalysisResult = {
   salaryDetail: string;
   summaryText: string;
   risks: RiskItem[];
+  compliance: ComplianceItem[];
 };
 
 const DEFAULT_ANALYSIS: AnalysisResult = {
@@ -60,6 +72,7 @@ const DEFAULT_ANALYSIS: AnalysisResult = {
   salaryDetail: '-',
   summaryText: '분석 결과를 불러오는 중입니다.',
   risks: [],
+  compliance: [],
 };
 
 function normalizeRiskLevel(value: unknown): RiskLevel {
@@ -116,6 +129,7 @@ function normalizeAnalysis(data: any): AnalysisResult {
   const risks: RiskItem[] = Array.isArray(data?.risk_clauses)
     ? data.risk_clauses.map((risk: any) => ({
         title:
+          risk?.title ??
           risk?.risk_type ??
           risk?.clause_number ??
           risk?.original_text?.slice?.(0, 24) ??
@@ -172,6 +186,16 @@ function normalizeAnalysis(data: any): AnalysisResult {
       data?.summary ??
       '계약서 분석 결과를 확인해보세요.',
     risks,
+    compliance: Array.isArray(data?.compliance_results)
+      ? data.compliance_results.map((c: any) => ({
+          clauseId: c?.clause_id ?? '',
+          clauseTitle: c?.clause_title ?? c?.clause_id ?? '조항',
+          status: (['위반', '주의', '적합', '검토불가'].includes(c?.status)
+            ? c.status
+            : '검토불가') as ComplianceStatus,
+          reason: c?.reason ?? '',
+        }))
+      : [],
   };
 }
 
@@ -282,6 +306,7 @@ export function ResultDashboard() {
           { role: 'bot', text: normalized.summaryText, type: 'text' },
           { role: 'bot', text: '', type: 'summary' },
           { role: 'bot', text: '', type: 'risks' },
+          { role: 'bot', text: '', type: 'compliance' },
           { role: 'bot', text: '', type: 'score' },
           {
             role: 'bot',
@@ -662,6 +687,51 @@ export function ResultDashboard() {
     );
   };
 
+  const ComplianceCards = () => {
+    if (analysis.compliance.length === 0) {
+      return (
+        <div className="rounded-[18px] border border-slate-100 bg-slate-50 p-4">
+          <p className="text-[13px] text-slate-400 text-center">법령 준수 데이터가 없어요.</p>
+        </div>
+      );
+    }
+
+    const statusStyle = (status: ComplianceStatus) => {
+      if (status === '위반') return { bg: 'border-red-100 bg-red-50', icon: <XCircle size={15} />, badge: 'bg-red-500', iconWrap: 'bg-gradient-to-br from-red-500 to-orange-500' };
+      if (status === '주의') return { bg: 'border-amber-100 bg-amber-50', icon: <AlertTriangle size={15} />, badge: 'bg-amber-500', iconWrap: 'bg-gradient-to-br from-yellow-500 to-amber-500' };
+      if (status === '적합') return { bg: 'border-emerald-100 bg-emerald-50', icon: <CheckCircle size={15} />, badge: 'bg-emerald-500', iconWrap: 'bg-gradient-to-br from-green-500 to-emerald-500' };
+      return { bg: 'border-slate-100 bg-slate-50', icon: <Scale size={15} />, badge: 'bg-slate-400', iconWrap: 'bg-gradient-to-br from-slate-400 to-slate-500' };
+    };
+
+    return (
+      <div className="space-y-3">
+        {analysis.compliance.map((item, index) => {
+          const s = statusStyle(item.status);
+          return (
+            <div key={`${item.clauseId}-${index}`} className={`rounded-[18px] border p-4 ${s.bg}`}>
+              <div className="flex items-start gap-3">
+                <div className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[12px] text-white ${s.iconWrap}`}>
+                  {s.icon}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h4 className="text-[14px] font-semibold text-slate-900">{item.clauseTitle}</h4>
+                    <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold text-white ${s.badge}`}>
+                      {item.status}
+                    </span>
+                  </div>
+                  {item.reason && (
+                    <p className="mt-2 text-[13px] leading-6 text-slate-600">{item.reason}</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
   const SummaryCards = () => (
     <div className="grid grid-cols-2 gap-4">
       <div className="min-w-0 rounded-[22px] border border-slate-100 bg-white px-5 py-6 shadow-sm">
@@ -868,6 +938,25 @@ export function ResultDashboard() {
                               </div>
 
                               <RiskCards />
+                            </div>
+                          </div>
+                        )}
+
+                        {message.type === 'compliance' && (
+                          <div className="flex gap-3">
+                            <div
+                              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[14px] text-white"
+                              style={{ background: 'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)' }}
+                            >
+                              <Bot size={16} />
+                            </div>
+                            <div className="max-w-xl flex-1 space-y-3">
+                              <div className="rounded-[20px] border border-white/90 bg-white px-4 py-3 shadow-sm">
+                                <p className="text-[15px] font-medium text-slate-900">
+                                  법령 준수 검사 결과예요.
+                                </p>
+                              </div>
+                              <ComplianceCards />
                             </div>
                           </div>
                         )}
@@ -1184,6 +1273,14 @@ export function ResultDashboard() {
 
                         <div className="mt-4">
                           <RiskCards />
+                        </div>
+
+                        <div className="mt-4 border-t border-slate-100 pt-4">
+                          <div className="flex items-center gap-2 mb-3">
+                            <Scale size={16} className="text-[#6C80DD]" />
+                            <h3 className="text-[15px] font-semibold text-slate-900">법령 준수 검사</h3>
+                          </div>
+                          <ComplianceCards />
                         </div>
                       </div>
 

--- a/src/app/screens/SharePage.tsx
+++ b/src/app/screens/SharePage.tsx
@@ -669,8 +669,8 @@ export default function SharePage() {
 
                                 <p className="text-sm font-extrabold text-[#26324D]">
                                   {getRiskTypeLabel(
-                                    risk?.risk_type ??
-                                      risk?.title ??
+                                    risk?.title ??
+                                      risk?.risk_type ??
                                       risk?.category ??
                                       risk?.clause_title ??
                                       risk?.clause

--- a/src/app/screens/SharePage.tsx
+++ b/src/app/screens/SharePage.tsx
@@ -517,26 +517,32 @@ export default function SharePage() {
                 <aside className="flex flex-col gap-5">
                   <section className="rounded-[28px] border border-[#E4E9F5] bg-white px-6 py-7 shadow-[0_14px_34px_rgba(95,117,177,0.08)]">
                     <div className="flex items-center gap-6">
-                      <div className="flex h-[128px] w-[128px] shrink-0 items-center justify-center rounded-full bg-[#E4E7EE] p-[13px]">
-                        <div
-                          className="flex h-full w-full items-center justify-center rounded-full"
-                          style={{
-                            background: `conic-gradient(#6B7CF6 ${
-                              score !== null ? score * 3.6 : 0
-                            }deg, #E4E7EE 0deg)`,
-                          }}
-                        >
-                          <div className="flex h-[82px] w-[82px] items-center justify-center rounded-full bg-white">
-                            <div className="flex items-end justify-center">
-                              <span className="text-[38px] font-extrabold leading-none tracking-[-0.06em] text-[#26324D]">
+                      <div className="shrink-0">
+                        {(() => {
+                          const s = Math.max(0, Math.min(100, score ?? 0));
+                          const size = 128;
+                          const sw = 14;
+                          const center = size / 2;
+                          const radius = (size - sw) / 2;
+                          const circumference = 2 * Math.PI * radius;
+                          const dashOffset = circumference * (1 - s / 100);
+                          return (
+                            <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} aria-label={`계약 안정도 ${s}점`}>
+                              <circle cx={center} cy={center} r={radius} fill="none" stroke="#E5E7EB" strokeWidth={sw} />
+                              <circle cx={center} cy={center} r={radius} fill="none" stroke="#6C80DD" strokeWidth={sw}
+                                strokeDasharray={circumference} strokeDashoffset={dashOffset}
+                                strokeLinecap="butt" transform={`rotate(-90 ${center} ${center})`} />
+                              <text x={center} y={center} textAnchor="middle" dominantBaseline="middle"
+                                fill="#0F172A" fontSize="30" fontWeight="600" letterSpacing="-0.04em" dy="-8">
                                 {score ?? '-'}
-                              </span>
-                              <span className="mb-1 ml-1 text-xs font-bold text-[#6E7890]">
+                              </text>
+                              <text x={center} y={center} textAnchor="middle" dominantBaseline="middle"
+                                fill="#64748B" fontSize="12" fontWeight="500" dy="20">
                                 점
-                              </span>
-                            </div>
-                          </div>
-                        </div>
+                              </text>
+                            </svg>
+                          );
+                        })()}
                       </div>
 
                       <div className="min-w-0">


### PR DESCRIPTION
## 관련 이슈
Closes #70 

## 변경 사항
공유 페이지의 안전점수 도넛 차트를 CSS 그라디언트 방식에서 결과 화면과 일관된 SVG 기반 방식으로 교체했습니다.

- **컴포넌트 구조 변경:** `src/app/screens/SharePage.tsx` 내부의 기존 `conic-gradient` 원형 div 구조를 제거하고, 두 개의 SVG `circle` 구조로 재구현했습니다.
- **스타일 및 비율 동기화:** `ResultDashboard`와 비율을 맞추기 위해 크기 `128x128`, 두께(`strokeWidth`) `14`를 적용했습니다.
- **디자인 디테일 반영:** - 배경 트랙 색상(`#E5E7EB`) 및 진행 호 색상(`#6C80DD`) 반영
  - 12시 방향 시작점 일치를 위해 `strokeLinecap="butt"` 및 `rotate(-90)` 속성 적용
- **텍스트 렌더링:** 차트 중앙의 점수와 "점" 단위를 SVG `text` 요소를 사용해 정렬했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [ ] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [ ] 로컬에서 AI 서비스 정상 기동 확인 (`uvicorn src.api.main:app --port 8001`)
- [x] 분석 파이프라인 단계별 동작 확인
- [x] 기존 기능 동작에 영향 없음 확인
- [x] 변경된 공유 페이지(`SharePage`)에서 도넛 차트가 정상적으로 렌더링되고 점수가 올바르게 표시되는지 확인

## 리뷰어를 위한 참고 사항
- 이번 작업은 UI의 일관성을 맞추기 위한 작업으로, `ResultDashboard` 컴포넌트의 SVG 차트 스펙(비율, 색상, stroke 속성)을 그대로 참고하여 이식했습니다.
- 차트의 시작점이 기존 CSS 방식과 달리 12시 방향에서 정방향으로 잘 흐르는지, 중앙 점수 텍스트가 깨지거나 치우치지 않고 중앙 정렬이 잘 유지되는지 위주로 리뷰해 주시면 감사하겠습니다!