### PR TITLE
fix: 계약서 분석 요청 엔드포인트 /request-analysis → /analyze 수정

### DIFF
--- a/src/app/screens/ContractManagementScreen.tsx
+++ b/src/app/screens/ContractManagementScreen.tsx
@@ -574,7 +574,7 @@ export default function ContractManagementScreen() {
     try {
       setAnalyzing(true);
 
-      await client.post(`/api/v1/contracts/${selectedContract.id}/request-analysis`);
+      await client.post(`/api/v1/contracts/${selectedContract.id}/analyze`);
 
       navigate(`/loading/${selectedContract.id}`);
     } catch {

--- a/src/app/screens/Upload.tsx
+++ b/src/app/screens/Upload.tsx
@@ -189,7 +189,7 @@ export function Upload() {
       }
 
       // 2. 분석 요청
-      await client.post(`/api/v1/contracts/${contractId}/request-analysis`);
+      await client.post(`/api/v1/contracts/${contractId}/analyze`);
 
       navigate(`/loading/${contractId}`);
     } catch (error: any) {


### PR DESCRIPTION
## 문제

계약서 업로드 후 분석이 시작되지 않고 업로드 화면에서 멈추는 현상.

백엔드 로그:
```
POST /api/v1/contracts/upload → 201 Created  ✅
POST /api/v1/contracts/{id}/request-analysis → 404 Not Found  ❌
```

## 원인

`Upload.tsx`, `ContractManagementScreen.tsx` 두 파일에서 존재하지 않는 엔드포인트 `/request-analysis`를 호출하고 있었다. 백엔드 실제 엔드포인트는 `/analyze`.

## 수정

| 파일 | 변경 전 | 변경 후 |
|---|---|---|
| `Upload.tsx:192` | `/request-analysis` | `/analyze` |
| `ContractManagementScreen.tsx:577` | `/request-analysis` | `/analyze` |

## 수정 파일

- `src/app/screens/Upload.tsx`
- `src/app/screens/ContractManagementScreen.tsx`

> 동일 문제가 `Loading.tsx`에서도 이전에 발생한 적 있음. 팀 내 엔드포인트 명칭 통일 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)