### PR TITLE
fix: 계약서 분석 요청 엔드포인트를 /analyze로 통일

### DIFF
--- a/src/app/screens/ContractManagementScreen.tsx
+++ b/src/app/screens/ContractManagementScreen.tsx
@@ -574,7 +574,7 @@ export default function ContractManagementScreen() {
     try {
       setAnalyzing(true);
 
-      await client.post(`/api/v1/contracts/${selectedContract.id}/request-analysis`);
+      await client.post(`/api/v1/contracts/${selectedContract.id}/analyze`);
 
       navigate(`/loading/${selectedContract.id}`);
     } catch {

--- a/src/app/screens/Upload.tsx
+++ b/src/app/screens/Upload.tsx
@@ -189,7 +189,7 @@ export function Upload() {
       }
 
       // 2. 분석 요청
-      await client.post(`/api/v1/contracts/${contractId}/request-analysis`);
+      await client.post(`/api/v1/contracts/${contractId}/analyze`);
 
       navigate(`/loading/${contractId}`);
     } catch (error: any) {


### PR DESCRIPTION
## 변경 사항
- 계약서 업로드 후 분석 요청 경로를 `/api/v1/contracts/{contractId}/analyze`로 수정했습니다.
- 계약서 관리 화면의 재분석 요청 경로도 동일하게 `/analyze`로 통일했습니다.

## 배경
백엔드 FastAPI 라우터는 `app.include_router(..., prefix="/api/v1/contracts")`와 `@router.post("/{contract_id}/analyze")` 조합으로 등록되어 있어 실제 공식 경로는 `POST /api/v1/contracts/{contract_id}/analyze`입니다. `/request-analysis`는 현재 백엔드 스펙과 맞지 않아 404를 유발할 수 있습니다.

## 확인 방법
- 백엔드 Swagger `/docs`에서 `POST /api/v1/contracts/{contract_id}/analyze` 경로 확인
- 프론트에서 계약서 업로드 후 분석 요청이 202 Accepted로 처리되는지 확인

## 테스트
- 로컬 코드 검색으로 `/request-analysis` 호출부 제거 확인
- 별도 자동 테스트는 실행하지 않았습니다.