### PR TITLE
fix: 채팅 메시지 요청 timeout 연장

### DIFF
--- a/src/app/screens/ChatSessionScreen.tsx
+++ b/src/app/screens/ChatSessionScreen.tsx
@@ -489,7 +489,7 @@ export default function ChatSessionScreen() {
       await client.post(`/api/v1/chat/sessions/${currentSessionId}/messages`, {
         content: nextText,
         message_type: 'question',
-      });
+      }, { timeout: 120000 });
 
       await refreshSelectedSession(currentSessionId);
 


### PR DESCRIPTION
## 변경 사항
- 채팅 메시지 전송 API 요청에 개별 timeout `120000ms`를 설정했습니다.

## 배경
공용 axios client의 기본 timeout은 10초입니다. AI 답변 생성이나 백엔드 처리 시간이 10초를 넘으면, 서버 처리가 진행 중이어도 프론트에서 요청 실패로 처리될 수 있습니다.

## 영향
- 채팅 메시지 전송 요청만 더 오래 기다립니다.
- 전체 API client 기본 timeout은 변경하지 않았습니다.

## 테스트
- 변경 범위 확인: `src/app/screens/ChatSessionScreen.tsx` 1줄 수정
- 별도 자동 테스트는 실행하지 않았습니다.

Closes #79