### PR TITLE
feat: 소셜 로그인 연동 및 API 엔드포인트 환경 설정 수정

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -14,6 +14,7 @@ import ChatSessionScreen from './screens/ChatSessionScreen';
 import ContractManagementScreen from './screens/ContractManagementScreen';
 import { PasswordReset } from './screens/PasswordReset';
 import SharePage from './screens/SharePage';
+import { SocialCallback } from './screens/SocialCallback';
 
 export const router = createBrowserRouter([
   {
@@ -81,6 +82,10 @@ export const router = createBrowserRouter([
 {
   path: '/share/:token',
   element: <SharePage />,
+},
+{
+  path: '/social-callback',
+  element: <SocialCallback />,
 },
 
 

--- a/src/app/screens/Login.tsx
+++ b/src/app/screens/Login.tsx
@@ -23,6 +23,11 @@ export function Login() {
     navigate('/');
   };
 
+  const API_URL = (import.meta as any).env.VITE_API_URL || 'http://127.0.0.1:8000';
+  const handleSocialLogin = (provider: 'google' | 'naver' | 'kakao') => {
+    window.location.href = `${API_URL}/api/v1/auth/${provider}`;
+  };
+
   const handleLogin = async () => {
     if (!email.trim() || !password.trim()) {
       setIsLoginErrorOpen(true);
@@ -213,6 +218,7 @@ export function Login() {
                 <div className="mt-5 space-y-3 sm:mt-6">
                   <button
                     type="button"
+                    onClick={() => handleSocialLogin('google')}
                     className="flex h-[52px] w-full items-center justify-center rounded-[16px] border border-slate-200/80 bg-white/94 px-4 text-[15px] font-medium text-slate-700 shadow-sm transition-colors hover:bg-white sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   >
                     <span className="mr-3 text-[22px] font-semibold text-[#4285F4]">
@@ -223,6 +229,7 @@ export function Login() {
 
                   <button
                     type="button"
+                    onClick={() => handleSocialLogin('naver')}
                     className="flex h-[52px] w-full items-center justify-center rounded-[16px] border border-slate-200/80 bg-white/94 px-4 text-[15px] font-medium text-slate-700 shadow-sm transition-colors hover:bg-white sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   >
                     <span className="mr-3 text-[22px] font-extrabold text-[#03C75A]">
@@ -233,6 +240,7 @@ export function Login() {
 
                   <button
                     type="button"
+                    onClick={() => handleSocialLogin('kakao')}
                     className="flex h-[52px] w-full items-center justify-center rounded-[16px] border border-[#F2D500] bg-[#FEE500] px-4 text-[15px] font-semibold text-[#191919] shadow-sm transition-colors hover:brightness-95 sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   >
                     <span className="mr-3 text-[18px] font-black">K</span>

--- a/src/app/screens/SignUp.tsx
+++ b/src/app/screens/SignUp.tsx
@@ -52,6 +52,11 @@ export function SignUp() {
     navigate('/login');
   };
 
+  const API_URL = (import.meta as any).env.VITE_API_URL || 'http://127.0.0.1:8000';
+  const handleSocialLogin = (provider: 'google' | 'naver' | 'kakao') => {
+    window.location.href = `${API_URL}/api/v1/auth/${provider}`;
+  };
+
   const handleLogin = () => {
     navigate('/login');
   };
@@ -455,6 +460,7 @@ export function SignUp() {
                 <div className="mt-5 space-y-3 sm:mt-6">
                   <button
                     type="button"
+                    onClick={() => handleSocialLogin('google')}
                     className="flex h-[52px] w-full items-center justify-center rounded-[16px] border border-slate-200/80 bg-white/94 px-4 text-[15px] font-medium text-slate-700 shadow-sm transition-colors hover:bg-white sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   >
                     <span className="mr-3 text-[22px] font-semibold text-[#4285F4]">
@@ -465,6 +471,7 @@ export function SignUp() {
 
                   <button
                     type="button"
+                    onClick={() => handleSocialLogin('naver')}
                     className="flex h-[52px] w-full items-center justify-center rounded-[16px] border border-slate-200/80 bg-white/94 px-4 text-[15px] font-medium text-slate-700 shadow-sm transition-colors hover:bg-white sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   >
                     <span className="mr-3 text-[22px] font-extrabold text-[#03C75A]">
@@ -475,6 +482,7 @@ export function SignUp() {
 
                   <button
                     type="button"
+                    onClick={() => handleSocialLogin('kakao')}
                     className="flex h-[52px] w-full items-center justify-center rounded-[16px] border border-[#F2D500] bg-[#FEE500] px-4 text-[15px] font-semibold text-[#191919] shadow-sm transition-colors hover:brightness-95 sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   >
                     <span className="mr-3 text-[18px] font-black">K</span>

--- a/src/app/screens/SocialCallback.tsx
+++ b/src/app/screens/SocialCallback.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+export function SocialCallback() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    const refreshToken = searchParams.get('refresh_token');
+
+    if (token) {
+      localStorage.setItem('accessToken', token);
+      if (refreshToken) {
+        localStorage.setItem('refreshToken', refreshToken);
+      }
+      navigate('/home', { replace: true });
+    } else {
+      navigate('/login', { replace: true });
+    }
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-[15px] text-slate-500">로그인 처리 중...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 관련 이슈
Closes #81 

## 변경 사항
- **환경 변수 추가**: `.env` 파일에 백엔드 로컬 주소(`VITE_API_URL`, `VITE_API_BASE_URL`)를 설정하여 API 요청이 정상적으로 가도록 수정했습니다.
- **엔드포인트 원복**: `Upload.tsx`, `ContractManagementScreen.tsx`에서 계약서 분석 API 경로를 백엔드 dev 브랜치 명세(`.../analyze`)에 맞춰 원복했습니다 (PR #78 상태 유지).
- **소셜 로그인 라우트 및 콜백 화면 구현**: 
  - 구글/네이버/카카오 로그인 버튼에 백엔드 인증 엔드포인트 핸들러를 연결했습니다.
  - 신규 화면 `SocialCallback.tsx`을 추가하여 URL 파라미터에서 토큰(`token`, `refresh_token`)을 읽어 `localStorage`에 저장하고 `/home`으로 리다이렉트되도록 구현했습니다.
  - `routes.tsx`에 `/social-callback` 경로를 새로 추가했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [ ] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [x] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 로컬에서 환경 변수 반영 및 백엔드 API 요청 타겟 주소 정상 확인
- [x] 소셜 로그인 버튼 클릭 시 지정된 백엔드 URL로 정상 이동 확인
- [x] `/social-callback` 경로 진입 시 쿼리 파라미터 토큰 추출 및 LocalStorage 저장 동작 확인

## 리뷰어를 위한 참고 사항
### ⚠️ 백엔드 개발자분들과의 협업 공유 사항
현재 백엔드의 소셜 로그인 콜백 엔드포인트(`/google/callback`, `/naver/callback`, `/kakao/callback`)가 성공 시 JSON 데이터를 리턴하고 있습니다. 

이번에 구현한 프론트엔드 로그인 플로우가 정상적으로 동작하려면, 백엔드 인증 완료 후 아래와 같이 **토큰을 쿼리 스트링에 담아 프론트엔드 주소로 리다이렉트**해주어야 합니다. 이 부분 백엔드 담당자분께 변경 요청 드려둔 상태이니 리뷰 시 참고 부탁드립니다!

```python
# 백엔드 반영 필요 코드 예시
return RedirectResponse(
    url=f"{settings.frontend_base_url}/social-callback?token={access_token}&refresh_token={refresh_token}"
)