### PR TITLE
fix: 프로필 화면 진입 시 프로필 이미지가 유실되거나 깜빡이는 UI 버그 수정

### DIFF
--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -35,6 +35,9 @@ export default function ProfileScreen() {
   });
 
   useEffect(() => {
+    const savedImage = localStorage.getItem('profileImage');
+    if (savedImage) setProfileImage(savedImage);
+
     const fetchUserInfo = async () => {
       try {
         const res = await client.get('/api/v1/auth/me');
@@ -46,7 +49,10 @@ export default function ProfileScreen() {
           createdAt: res.data.created_at || res.data.createdAt || '',
         });
 
-        setProfileImage(res.data.profile_image || res.data.profileImage || null);
+        const serverImage = res.data.profile_image || res.data.profileImage;
+        if (serverImage) {
+          setProfileImage(serverImage);
+        }
       } catch (error) {
         console.error('유저 정보 불러오기 실패:', error);
         const stored = localStorage.getItem('userInfo');
@@ -59,8 +65,6 @@ export default function ProfileScreen() {
             createdAt: u.created_at || u.createdAt || '',
           });
         }
-        const savedImage = localStorage.getItem('profileImage');
-        if (savedImage) setProfileImage(savedImage);
       }
     };
 


### PR DESCRIPTION
## 관련 이슈
Closes #85 

## 변경 사항
프로필 화면(`ProfileScreen.tsx`)에 진입할 때 로컬에 저장되어 있던 프로필 이미지가 순간적으로 사라지거나 완전히 안 보이게 되는 UI 렌더링 동기화 문제를 해결했습니다.

### 상세 수정 내용
* **초기 렌더링 속도 개선:** `useEffect` 내부 최상단에서 `localStorage.getItem('profileImage')`를 즉시 조회하고 화면 상태에 반영하여, API 응답을 기다리는 동안에도 유저가 설정한 이미지가 바로 표시되도록 수정했습니다.
* **서버 데이터 조건부 반영:** 내 정보 조회 API(`/api/v1/auth/me`) 요청 성공 후, 서버 응답 데이터에 `profile_image` 또는 `profileImage` 값이 **실제로 존재할 때만** 상태를 업데이트(`setProfileImage`)하도록 방어 코드를 작성했습니다.
* **기존 이미지 유실 방지:** 백엔드 DB에 별도의 프로필 이미지 주소가 저장되어 있지 않더라도(null 또는 undefined), 프론트엔드 로컬 스토리지에 유지되고 있던 이미지가 초기화되지 않고 안전하게 보존됩니다.
* **에러 핸들링 간소화:** `catch` 블록 내 유저 정보 fallback 로직은 그대로 유지하면서, 중복 처리되던 이미지 관련 예외 코드를 깔끔하게 다듬었습니다.

## 변경 유형
- [ ] 새 기능 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [ ] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 프로필 화면 진입 시 기존 저장된 이미지가 깜빡임 없이 즉시 표시되는지 확인
- [x] API 응답에 프로필 이미지가 없을 때도 로컬 스토리지가 유지되며 이미지가 깨지지 않는지 확인
- [x] `npm run build`를 통한 프론트엔드 빌드 정상 통과 확인
- [x] 기존 기능 및 백엔드 API 호출 스펙에 영향이 없음을 확인

## 리뷰어를 위한 참고 사항
* **로직 안전성:** 요구사항에 맞춰 API 엔드포인트나 백엔드 데이터 송수신 흐름은 단 한 줄도 변경하지 않았습니다. 순수하게 프론트엔드의 상태 업데이트 시점과 조건문(`if (serverImage)`)만 보강한 안전한 수정입니다.
* **화면 깜빡임 개선:** 화면에 진입하자마자 로컬 데이터를 먼저 끌어다 쓰기 때문에 사용자가 느끼던 '이미지가 사라졌다 다시 나타나는 현상'이 완벽하게 해결되었으니 이 부분 위주로 크로스 체크 부탁드립니다.