### PR TITLE
feat: 채팅 세션 이력 관리 화면(ChatSessionScreen) 개편 및 복합 최신순 정렬 적용

### DIFF
--- a/src/app/screens/ChatSessionScreen.tsx
+++ b/src/app/screens/ChatSessionScreen.tsx
@@ -29,6 +29,21 @@ type RawMessage = {
 type RawSession = {
   id: number;
   contract_id?: number | null;
+  contractId?: number | null;
+  contract?: {
+    id?: number;
+    contract_id?: number;
+    title?: string;
+    name?: string;
+    file_name?: string;
+    filename?: string;
+    original_filename?: string;
+  } | null;
+  contract_title?: string | null;
+  contractTitle?: string | null;
+  contract_file_name?: string | null;
+  contractFileName?: string | null;
+  original_filename?: string | null;
   title?: string;
   total_message_count?: number;
   message_count?: number;
@@ -66,9 +81,12 @@ type Message = {
 
 type Session = {
   id: number;
+  contractId: number | null;
+  contractName: string | null;
   title: string;
   createdAt: string;
   updatedAt: string;
+  sortTime: number;
   messageCount: number;
   preview: string;
   messages: Message[];
@@ -108,6 +126,13 @@ const formatTime = (value?: string | null) => {
   });
 };
 
+const getTimeValue = (value?: string | null) => {
+  if (!value) return 0;
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+};
+
 const normalizeMessage = (message: RawMessage, index: number): Message => {
   const sender = String(message.sender ?? message.role ?? '').toLowerCase();
   const rawContent = message.content ?? message.message ?? message.text ?? '';
@@ -143,14 +168,46 @@ const normalizeMessage = (message: RawMessage, index: number): Message => {
 const normalizeSession = (session: RawSession): Session => {
   const messages = (session.messages ?? []).map(normalizeMessage);
   const lastMessage = messages[messages.length - 1];
+  const contractId =
+    session.contract_id ??
+    session.contractId ??
+    session.contract?.id ??
+    session.contract?.contract_id ??
+    null;
+
+  const contractName =
+    session.contract?.original_filename ??
+    session.contract?.file_name ??
+    session.contract?.filename ??
+    session.contract?.title ??
+    session.contract?.name ??
+    session.contract_title ??
+    session.contractTitle ??
+    session.contract_file_name ??
+    session.contractFileName ??
+    session.original_filename ??
+    null;
+
+  const title = session.title?.trim();
+  const shouldUseContractName =
+    contractName && (!title || title.startsWith('채팅 세션') || title.startsWith('새 채팅 세션'));
+  const sortSource =
+    session.last_message_at ??
+    session.updated_at ??
+    session.updatedAt ??
+    session.created_at ??
+    session.createdAt;
 
   return {
     id: session.id,
-    title: session.title ?? `채팅 세션 ${session.id}`,
+    contractId,
+    contractName,
+    title: shouldUseContractName ? contractName : title || `채팅 세션 ${session.id}`,
     createdAt: formatDate(session.created_at ?? session.createdAt),
     updatedAt: formatDate(
       session.last_message_at ?? session.updated_at ?? session.updatedAt
     ),
+    sortTime: getTimeValue(sortSource),
     messageCount:
       session.total_message_count ??
       session.message_count ??
@@ -159,6 +216,7 @@ const normalizeSession = (session: RawSession): Session => {
       0,
     preview:
       session.preview ??
+      (contractName ? `${contractName} 기반 상담` : null) ??
       session.last_question ??
       session.first_question ??
       session.last_message ??
@@ -216,8 +274,23 @@ function SessionListItem({
                 <Clock3 className="h-3 w-3" />
                 {session.createdAt}
               </span>
+              <span
+                className={`rounded-full px-2 py-0.5 font-medium ${
+                  session.contractId
+                    ? 'bg-emerald-50 text-emerald-600'
+                    : 'bg-slate-100 text-slate-500'
+                }`}
+              >
+                {session.contractId ? '계약서 연결됨' : '일반 상담'}
+              </span>
               <span>{session.messageCount}개</span>
             </div>
+
+            {session.contractName && (
+              <p className="mt-1 truncate text-[10px] font-medium text-[#6C80DD]">
+                {session.contractName}
+              </p>
+            )}
           </div>
         </button>
 
@@ -296,7 +369,9 @@ export default function ChatSessionScreen() {
         ? res.data
         : res.data.sessions ?? [];
 
-      const normalizedSessions = rawSessions.map(normalizeSession);
+      const normalizedSessions = rawSessions
+        .map(normalizeSession)
+        .sort((a, b) => b.sortTime - a.sortTime || b.id - a.id);
 
       setSessions((prev) => {
         const selectedDetail = prev.find(
@@ -330,11 +405,14 @@ export default function ChatSessionScreen() {
   }, []);
 
   const filteredSessions = useMemo(() => {
-    return sessions.filter(
-      (session) =>
-        session.title.toLowerCase().includes(search.toLowerCase()) ||
-        session.preview.toLowerCase().includes(search.toLowerCase())
-    );
+    return sessions
+      .filter(
+        (session) =>
+          session.title.toLowerCase().includes(search.toLowerCase()) ||
+          session.preview.toLowerCase().includes(search.toLowerCase()) ||
+          (session.contractName ?? '').toLowerCase().includes(search.toLowerCase())
+      )
+      .sort((a, b) => b.sortTime - a.sortTime || b.id - a.id);
   }, [sessions, search]);
 
   const visibleSessions = listOpen
@@ -398,12 +476,14 @@ export default function ChatSessionScreen() {
     try {
       const res = await client.post('/api/v1/chat/sessions', {
         contract_id: null,
-        title: `새 채팅 세션 ${sessions.length + 1}`,
+        title: `일반 채팅 세션 ${sessions.length + 1}`,
       });
 
       const newSession = normalizeSession(res.data);
 
-      setSessions((prev) => [newSession, ...prev]);
+      setSessions((prev) =>
+        [newSession, ...prev].sort((a, b) => b.sortTime - a.sortTime || b.id - a.id)
+      );
       setSelectedSessionId(newSession.id);
       setDetailOpen(true);
       setMessageInput('');
@@ -473,16 +553,19 @@ export default function ChatSessionScreen() {
     };
 
     setSessions((prev) =>
-      prev.map((session) =>
-        session.id === currentSessionId
-          ? {
-              ...session,
-              preview: nextText,
-              messageCount: session.messageCount + 1,
-              messages: [...session.messages, optimisticUserMessage],
-            }
-          : session
-      )
+      prev
+        .map((session) =>
+          session.id === currentSessionId
+            ? {
+                ...session,
+                preview: nextText,
+                sortTime: optimisticUserMessage.id,
+                messageCount: session.messageCount + 1,
+                messages: [...session.messages, optimisticUserMessage],
+              }
+            : session
+        )
+        .sort((a, b) => b.sortTime - a.sortTime || b.id - a.id)
     );
 
     try {
@@ -727,9 +810,32 @@ export default function ChatSessionScreen() {
                           </div>
 
                           <div className="rounded-xl bg-white px-3 py-2">
+                            <p className="text-[10px] text-slate-400">세션 유형</p>
+                            <p
+                              className={`mt-1 text-[11px] font-semibold sm:text-[12px] ${
+                                selectedSession.contractId
+                                  ? 'text-emerald-600'
+                                  : 'text-slate-600'
+                              }`}
+                            >
+                              {selectedSession.contractId ? '계약서 연결 상담' : '일반 상담'}
+                            </p>
+                          </div>
+
+                          <div className="rounded-xl bg-white px-3 py-2">
                             <p className="text-[10px] text-slate-400">세션 제목</p>
                             <p className="mt-1 truncate text-[11px] font-medium text-slate-700 sm:text-[12px]">
                               {selectedSession.title}
+                            </p>
+                          </div>
+
+                          <div className="rounded-xl bg-white px-3 py-2">
+                            <p className="text-[10px] text-slate-400">연결 계약서</p>
+                            <p className="mt-1 truncate text-[11px] font-medium text-slate-700 sm:text-[12px]">
+                              {selectedSession.contractName ??
+                                (selectedSession.contractId
+                                  ? `계약서 ID ${selectedSession.contractId}`
+                                  : '연결된 계약서 없음')}
                             </p>
                           </div>
                         </div>


### PR DESCRIPTION
## 관련 이슈
Closes #87 

## 변경 사항
채팅 세션 이력 화면(`ChatSessionScreen.tsx`)에서 계약서 연동 세션과 일반 상담 세션을 명확히 구분하고, 탐색 경험을 높이기 위해 검색 범위 확장 및 실시간 최신순 정렬 로직을 도입했습니다.

### 상세 변경 내용
1. **데이터 규격 정규화 및 확장 (`normalizeSession`)**
   * 서버 API 응답 데이터에 맞춰 계약서 관련 선택적(optional) 필드(`contract_id`, `contractId`, `contract_title`, `contractTitle` 등)를 처리할 수 있도록 타입을 보강했습니다.
   * `normalizeSession`을 거치며 `contractId`와 `contractName`이 명확하게 추출되도록 매핑했습니다.

2. **세션 식별을 위한 UI 요소 추가 및 개선**
   * **대체 텍스트 규칙:** 제목이 없는 세션이거나 기본 제목(`채팅 세션`, `새 채팅 세션`)인 경우 추출된 계약서명으로 타이틀을 대체합니다. 미리보기가 비어있다면 `${contractName} 기반 상담`으로 처리합니다.
   * **상태 배지 및 정보 노출:** 목록 카드에 `계약서 연결됨` / `일반 상담` 배지를 추가(가운데 정렬)하고 연동된 계약서 이름을 표기했습니다.
   * **상세 정보 패널 강화:** 우측 세션 상세 정보 영역에 '세션 유형' 및 '연결 계약서' 메타데이터를 투명하게 노출합니다.
   * **새 독립 세션 포맷:** 새로 생성하는 독립 세션은 요구사항에 맞춰 `일반 채팅 세션 N` 형태로 넘버링 타이틀이 지정됩니다.

3. **실시간 복합 정렬(Sorting) 및 검색 기능 개선**
   * **정렬 가중치 적용:** `last_message_at` > `updated_at` > `created_at` 순으로 타임스탬프를 비교하고, 시간이 동일하거나 없는 예외 케이스에는 `id` 값이 큰 순서(역순)로 최상단에 오도록 복합 정렬 함수를 바인딩했습니다.
   * **동적 갱신 파이프라인:** 초기 로딩, 검색 필터링 시점뿐만 아니라 **새 세션 생성 직후**, **메시지 전송 직후(`sortTime` 동적 갱신)**에도 해당 세션이 실시간으로 목록 최상단으로 끌어올려 지도록 상태 흐름을 제어했습니다.
   * **검색 확장:** 기존 제목(`title`), 미리보기(`preview`) 텍스트 매칭 외에 정규화된 계약서명(`contractName`) 키워드로도 세션 목록을 필터링할 수 있도록 보강했습니다.

4. **기존 API 연동 구조 유지**
   * 기존 백엔드 API 엔드포인트(`GET/POST/DELETE /api/v1/chat/sessions...`) 주소 및 데이터 호출 명세는 단 하나도 변경하지 않고 순수 클라이언트 상태와 UI 레이어만 안전하게 개선했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [x] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 계약서 연동 채팅과 일반 상담 채팅이 배지 및 텍스트로 정상 구분되어 출력되는지 확인
- [x] 특정 세션에서 메시지를 전송하자마자 해당 세션 카드가 실시간으로 목록 맨 위로 이동하는지 확인
- [x] 계약서명 단어로 검색 시 해당 계약서와 연동된 세션 목록이 올바르게 필터링되는지 확인
- [x] `npm run build` 스크립트 실행 시 타입 에러 없이 정상적으로 빌드가 완료되는지 확인

## 리뷰어를 위한 참고 사항
* **정렬 로직 검증:** 메시지를 보낼 때 화면 왼쪽 목록에서 해당 세션이 실시간으로 최상단으로 재정렬되는 UX 처리가 매끄럽게 동작하는지 집중적으로 확인 부탁드립니다.
* **UI 일관성:** 기존 CLAIR 대시보드가 가진 배지 스타일, 폰트 및 중앙 정렬 명세를 엄격히 준수하여 디자인 톤앤매너를 유지했습니다.