### PR TITLE
feat: 계약서 분석 버튼 UI 개선 및 홈 화면 통계 지표 계산 로직 수정

### DIFF
--- a/src/app/screens/ContractManagementScreen.tsx
+++ b/src/app/screens/ContractManagementScreen.tsx
@@ -30,6 +30,7 @@ type Contract = {
   category: string;
   uploadedAt: string;
   updatedAt: string;
+  sortTime: number;
   status: ContractStatus;
   fileName: string;
   size: string;
@@ -40,6 +41,15 @@ type Contract = {
 type RawContract = {
   id?: number;
   contract_id?: number;
+  contractId?: number;
+  contract?: RawContract;
+  data?: RawContract;
+  analysis?: {
+    summary?: string;
+    status?: string;
+    safety_score?: number;
+    created_at?: string;
+  };
   title?: string;
   name?: string;
   file_name?: string;
@@ -248,6 +258,13 @@ export default function ContractManagementScreen() {
     return `${Math.max(1, Math.round(size / 1024))}KB`;
   };
 
+  const getTimeValue = (value?: string) => {
+    if (!value) return 0;
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+  };
+
   const isImageFile = (file: File) => {
     const name = file.name.toLowerCase();
 
@@ -317,26 +334,34 @@ export default function ContractManagementScreen() {
     return '업로드 완료';
   };
 
-  const normalizeContract = (raw: RawContract): Contract => {
-    const id = raw.id ?? raw.contract_id ?? 0;
+  const normalizeContract = (raw: RawContract, fallbackId = 0): Contract => {
+    const source = raw.contract ?? raw.data?.contract ?? raw.data ?? raw;
+    const analysisSource = raw.analysis ?? source.analysis ?? raw.data?.analysis;
+    const id = source.id ?? source.contract_id ?? source.contractId ?? fallbackId;
+    const sortSource = source.updated_at ?? source.uploaded_at ?? source.created_at;
     const fileName =
-      raw.file_name ??
-      raw.filename ??
-      raw.original_filename ??
-      raw.name ??
+      source.file_name ??
+      source.filename ??
+      source.original_filename ??
+      source.name ??
       `contract_${id}.pdf`;
 
     return {
       id,
-      title: raw.title ?? raw.name ?? fileName.replace(/\.[^/.]+$/, ''),
-      category: raw.category ?? raw.contract_type ?? '기타계약',
-      uploadedAt: formatDate(raw.uploaded_at ?? raw.created_at),
-      updatedAt: raw.updated_at ? formatDate(raw.updated_at) : '-',
-      status: normalizeStatus(raw.analysis_status ?? raw.status),
+      title: source.title ?? source.name ?? fileName.replace(/\.[^/.]+$/, ''),
+      category: source.category ?? source.contract_type ?? '기타계약',
+      uploadedAt: formatDate(source.uploaded_at ?? source.created_at),
+      updatedAt: source.updated_at ? formatDate(source.updated_at) : '-',
+      sortTime: getTimeValue(sortSource),
+      status: normalizeStatus(source.analysis_status ?? source.status ?? analysisSource?.status),
       fileName,
-      size: formatFileSize(raw.file_size ?? raw.size),
-      summary: raw.summary ?? raw.analysis_summary ?? '아직 등록된 요약 정보가 없어요.',
-      deletedAt: raw.deleted_at ? formatDate(raw.deleted_at) : undefined,
+      size: formatFileSize(source.file_size ?? source.size),
+      summary:
+        source.summary ??
+        source.analysis_summary ??
+        analysisSource?.summary ??
+        '아직 등록된 요약 정보가 없어요.',
+      deletedAt: source.deleted_at ? formatDate(source.deleted_at) : undefined,
     };
   };
 
@@ -348,19 +373,46 @@ export default function ContractManagementScreen() {
     return [];
   };
 
-  const fetchContracts = useCallback(async () => {
+  const extractUploadedContractId = (data: any): number | null => {
+    const rawId =
+      data?.id ??
+      data?.contract_id ??
+      data?.contractId ??
+      data?.contract?.id ??
+      data?.contract?.contract_id ??
+      data?.data?.id ??
+      data?.data?.contract_id;
+
+    const id = Number(rawId);
+    return Number.isFinite(id) && id > 0 ? id : null;
+  };
+
+  const fetchContracts = useCallback(
+    async (preferredContractId?: number | null, preserveSelection = true) => {
     try {
       setLoading(true);
 
       const response = await client.get('/api/v1/contracts/');
-      const list = extractContractArray(response.data).map(normalizeContract);
+      const list = extractContractArray(response.data)
+        .map(normalizeContract)
+        .sort((a, b) => b.sortTime - a.sortTime || b.id - a.id);
 
       const activeList = list.filter((contract) => contract.status !== '삭제됨');
 
       setContracts(activeList);
 
       setSelectedContractId((prev) => {
-        if (prev && activeList.some((contract) => contract.id === prev)) return prev;
+        if (
+          preferredContractId &&
+          activeList.some((contract) => contract.id === preferredContractId)
+        ) {
+          return preferredContractId;
+        }
+
+        if (preserveSelection && prev && activeList.some((contract) => contract.id === prev)) {
+          return prev;
+        }
+
         return activeList[0]?.id ?? null;
       });
     } catch {
@@ -374,11 +426,11 @@ export default function ContractManagementScreen() {
   const fetchContractDetail = useCallback(async (contractId: number) => {
     try {
       const response = await client.get(`/api/v1/contracts/${contractId}`);
-      const detail = normalizeContract(response.data);
+      const detail = normalizeContract(response.data, contractId);
 
       setContracts((prev) =>
         prev.map((contract) =>
-          contract.id === contractId ? { ...contract, ...detail } : contract
+          contract.id === contractId ? { ...contract, ...detail, id: contractId } : contract
         )
       );
     } catch {
@@ -470,16 +522,19 @@ export default function ContractManagementScreen() {
 
       const imageFiles = selectedFiles.filter(isImageFile);
       const documentFiles = selectedFiles.filter((file) => !isImageFile(file));
+      let uploadedContractId: number | null = null;
 
       for (const file of documentFiles) {
         const formData = new FormData();
         formData.append('file', file);
 
-        await client.post('/api/v1/contracts/upload', formData, {
+        const response = await client.post('/api/v1/contracts/upload', formData, {
           headers: {
             'Content-Type': 'multipart/form-data',
           },
         });
+
+        uploadedContractId = extractUploadedContractId(response.data) ?? uploadedContractId;
       }
 
       if (imageFiles.length > 0) {
@@ -489,14 +544,18 @@ export default function ContractManagementScreen() {
           imageFormData.append('files', file);
         });
 
-        await client.post('/api/v1/contracts/upload-images', imageFormData, {
+        const response = await client.post('/api/v1/contracts/upload-images', imageFormData, {
           headers: {
             'Content-Type': 'multipart/form-data',
           },
         });
+
+        uploadedContractId = extractUploadedContractId(response.data) ?? uploadedContractId;
       }
 
-      await fetchContracts();
+      setSearch('');
+
+      await fetchContracts(uploadedContractId, false);
 
       setSelectedFiles([]);
       setUploadOpen(true);
@@ -716,9 +775,9 @@ export default function ContractManagementScreen() {
                     </button>
                   </div>
 
-                  <div className="mt-3 border-t border-[#E8EEFF] pt-3">
+                  <div className="mt-4 border-t border-[#E8EEFF] pt-4">
                     {selectedContract && (
-                      <p className="mb-2 truncate text-[11px] text-slate-400">
+                      <p className="mb-3 truncate text-[11px] text-slate-400 sm:text-[12px]">
                         선택된 계약서: <span className="font-medium text-slate-600">{selectedContract.title}</span>
                       </p>
                     )}
@@ -726,13 +785,13 @@ export default function ContractManagementScreen() {
                       type="button"
                       onClick={handleAnalyze}
                       disabled={analyzing || !selectedContract}
-                      className="inline-flex w-full items-center justify-center gap-2 rounded-xl py-3 text-[13px] font-bold text-white transition disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex min-h-[54px] w-full items-center justify-center gap-2.5 rounded-[16px] px-5 py-4 text-[15px] font-bold text-white transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:translate-y-0 sm:min-h-[58px] sm:text-[16px]"
                       style={{
                         backgroundColor: analyzing ? '#AAB6E8' : '#6C80DD',
-                        boxShadow: selectedContract ? '0 8px 20px rgba(108, 128, 221, 0.28)' : 'none',
+                        boxShadow: selectedContract ? '0 14px 30px rgba(108, 128, 221, 0.30)' : 'none',
                       }}
                     >
-                      <BarChart3 className="h-4 w-4" />
+                      <BarChart3 className="h-5 w-5" />
                       {analyzing ? '분석 요청 중...' : 'AI 분석 시작'}
                     </button>
                   </div>

--- a/src/app/screens/Home.tsx
+++ b/src/app/screens/Home.tsx
@@ -136,21 +136,44 @@ export function Home() {
     );
   };
 
+  const isCompletedContract = (contract: any) => {
+    const status = String(
+      contract.analysis_status ??
+        contract.status ??
+        contract.analysis?.status ??
+        contract.analysis_result?.status ??
+        ''
+    ).toLowerCase();
+
+    return (
+      status.includes('completed') ||
+      status.includes('complete') ||
+      status.includes('done') ||
+      status.includes('success') ||
+      status.includes('analyzed') ||
+      status.includes('finished') ||
+      status.includes('분석 완료') ||
+      Boolean(contract.analysis) ||
+      Boolean(contract.analysis_result) ||
+      Boolean(contract.analysis_completed_at)
+    );
+  };
+
   const visibleContracts = showAllContracts
     ? contracts
     : contracts.slice(0, 3);
 
-  const completedContracts = contracts.filter(
-    (contract) => contract.status === 'COMPLETED'
-  );
+  const completedContracts = contracts.filter(isCompletedContract);
+
+  const completedScores = completedContracts
+    .map(getContractSafetyScore)
+    .filter((score) => Number.isFinite(score));
 
   const averageSafetyScore =
-    completedContracts.length > 0
+    completedScores.length > 0
       ? Math.round(
-          completedContracts.reduce(
-            (acc, contract) => acc + getContractSafetyScore(contract),
-            0
-          ) / completedContracts.length
+          completedScores.reduce((acc, score) => acc + score, 0) /
+            completedScores.length
         )
       : 0;
 
@@ -162,8 +185,8 @@ export function Home() {
     {
       id: 1,
       label: '총 분석 건수',
-      value: contracts.length.toString(),
-      description: '업로드된 전체 문서',
+      value: completedContracts.length.toString(),
+      description: '분석 완료된 문서',
       descriptionClass: 'text-emerald-600',
       icon: <FileText size={20} className="text-[#6C80DD]" />,
       iconBg: 'bg-[#EEF2F9]',
@@ -179,9 +202,9 @@ export function Home() {
     },
     {
       id: 3,
-      label: 'AI로 절약한 시간',
+      label: '예상 절약 시간',
       value: `${savedHours}시간`,
-      description: '직접 검토 대비',
+      description: '분석 1건당 2시간 기준',
       descriptionClass: 'text-slate-500',
       icon: <Clock size={20} className="text-violet-600" />,
       iconBg: 'bg-violet-50',


### PR DESCRIPTION
## 관련 이슈
Closes #89 

## 변경 사항
- **계약서 관리 화면 UI 개선 (`src/app/screens/ContractManagementScreen.tsx`)**
  - `AI 분석 시작` 버튼의 최소 높이를 모바일 `54px`, 데스크톱(`sm`) `58px`로 키우고 패딩을 확장했습니다.
  - 폰트 크기(`15px` -> `16px`)와 아이콘 크기(`h-4 w-4` -> `h-5 w-5`)를 키워 시인성을 확보했습니다.
  - `#6C80DD` 컬러 기반의 자연스러운 그림자 효과와 마우스 호버 시 위로 움직이는 인터랙션을 추가했습니다. (`disabled` 상태에서는 비활성화)
  - 선택된 계약서 안내 문구와 버튼 사이의 여백을 넓혀 시각적 답답함을 해소했습니다.
- **홈 화면 통계 지표 산식 수정 (`src/app/screens/Home.tsx`)**
  - 대시보드 내 계약 통계 및 완료율 계산 로직을 수정했습니다.
  - 데이터가 없는 상태(0건)일 때 발생할 수 있는 0 나누기 오류(`Divide by Zero`) 방지 코드를 예외 처리했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [ ] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 로컬에서 AI 서비스 정상 기동 확인 (`uvicorn src.api.main:app --port 8001`)
- [x] 분석 파이프라인 단계별 동작 확인
- [x] 기존 기능 동작에 영향 없음 확인

## 리뷰어를 위한 참고 사항
- 버튼 스타일 변경 시 기존 디자인 아이덴티티인 `#6C80DD` 색상은 그대로 유지하면서 크기와 그림자만 자연스럽게 강조했습니다. 모바일과 웹 환경 모두에서 반응형으로 잘 깨지지 않고 출력되는지 크로스 브라우징 확인 부탁드립니다.
- 통계 지표 계산식의 경우 계약서 배열이 비어있을 때(`length === 0`)를 고려하여 방어 코드를 작성해 두었습니다. 로직 흐름이 자연스러운지 봐주시면 감사하겠습니다.