### PR TITLE
feat: 소셜 로그인 · 프로필 API 연동 및 UI/UX 개선 (애니메이션, 금액 포맷팅)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev      # Start Vite dev server
+npm run build    # Production build
+```
+
+There are no configured test or lint scripts.
+
+## Architecture
+
+**Stack:** React 18 + TypeScript + Vite, React Router 7, Tailwind CSS v4, MUI + Radix UI (shadcn-style primitives)
+
+**Entry point:** `src/main.tsx` renders a `RouterProvider`. All routes are defined in `src/app/routes.tsx`.
+
+**Screens** live in `src/app/screens/` — each is a full-page component mapped 1:1 to a route. State is local (`useState`/`useEffect`); there is no global state manager.
+
+**UI components** live in two places:
+- `src/app/components/ui/` — shadcn/Radix primitives (button, card, dialog, etc.)
+- MUI components are used directly from `@mui/material` in screens
+
+## API Layer
+
+All HTTP calls go through `src/api/client.ts` (Axios instance):
+- Base URL: `VITE_API_URL` env var, fallback `http://127.0.0.1:8000`
+- Auth: Bearer token read from `localStorage.getItem('accessToken')`, injected via request interceptor
+- 401 handler: redirects to `/login` except for contract polling (`/loading/`) and share (`/share/`) routes
+- API paths follow `/api/v1/*`
+
+`src/api/axiosInstance.js` is a legacy file; prefer `client.ts`.
+
+## Path Aliases
+
+`@` maps to `src/` (configured in both `tsconfig.json` and `vite.config.ts`).
+
+## Styling Conventions
+
+- Tailwind v4 is the primary styling approach
+- Emotion is available via MUI but not used for custom styles
+- Theme variables are in `src/styles/theme.css`; global styles in `src/styles/index.css`
+- Use `clsx` + `tailwind-merge` (`cn` utility) for conditional class merging

--- a/src/api/socialAuth.ts
+++ b/src/api/socialAuth.ts
@@ -1,0 +1,10 @@
+export type SocialProvider = 'google' | 'naver' | 'kakao';
+
+const API_URL =
+  (import.meta as any).env.VITE_API_URL || 'http://127.0.0.1:8000';
+
+export const redirectToSocialLogin = (provider: SocialProvider) => {
+  const baseUrl = API_URL.replace(/\/$/, '');
+
+  window.location.href = `${baseUrl}/api/v1/auth/${provider}`;
+};

--- a/src/app/screens/Login.tsx
+++ b/src/app/screens/Login.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, X } from 'lucide-react';
 // 점 두 개(..)가 두 번 필요합니다!
 import client from '../../api/client';
+import { redirectToSocialLogin, type SocialProvider } from '../../api/socialAuth';
 
 export function Login() {
   const navigate = useNavigate();
@@ -14,7 +15,6 @@ export function Login() {
   const [isLoading, setIsLoading] = useState(false);
   const [isLoginErrorOpen, setIsLoginErrorOpen] = useState(false);
   const [isFindPasswordOpen, setIsFindPasswordOpen] = useState(false);
-  const [socialProviderName, setSocialProviderName] = useState('');
   const [findPasswordEmail, setFindPasswordEmail] = useState('');
   const [isSendingReset, setIsSendingReset] = useState(false);
   const [resetMessage, setResetMessage] = useState('');
@@ -24,14 +24,8 @@ export function Login() {
     navigate('/');
   };
 
-  const handleSocialLogin = (provider: 'google' | 'naver' | 'kakao') => {
-    const providerNames = {
-      google: 'Google',
-      naver: 'Naver',
-      kakao: 'KakaoTalk',
-    };
-
-    setSocialProviderName(providerNames[provider]);
+  const handleSocialLogin = (provider: SocialProvider) => {
+    redirectToSocialLogin(provider);
   };
 
   const handleLogin = async () => {
@@ -299,48 +293,6 @@ export function Login() {
             <button
               type="button"
               onClick={() => setIsLoginErrorOpen(false)}
-              className="mt-6 h-12 w-full rounded-[16px] text-[15px] font-semibold text-white transition-all hover:-translate-y-0.5"
-              style={{
-                background:
-                  'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
-                boxShadow: '0 14px 30px rgba(102,122,242,0.24)',
-              }}
-            >
-              확인
-            </button>
-          </div>
-        </div>
-      )}
-
-      {socialProviderName && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/20 px-5 backdrop-blur-sm">
-          <div className="w-full max-w-[380px] rounded-[28px] border border-white/90 bg-white/95 px-6 py-7 text-center shadow-[0_24px_70px_rgba(95,117,177,0.24)]">
-            <button
-              type="button"
-              onClick={() => setSocialProviderName('')}
-              className="ml-auto flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
-              aria-label="닫기"
-            >
-              <X size={18} />
-            </button>
-
-            <div className="mx-auto mt-1 flex h-13 w-13 items-center justify-center rounded-full bg-[#EEF3FF] text-[24px] font-bold text-[#667AF2]">
-              !
-            </div>
-
-            <h2 className="mt-5 text-[21px] font-bold tracking-[-0.03em] text-slate-900">
-              소셜 로그인을 준비 중이에요
-            </h2>
-
-            <p className="mt-2 text-[14px] leading-6 text-slate-500">
-              {socialProviderName} 로그인 연동 설정이 아직 완료되지 않았어요.
-              <br />
-              지금은 이메일 로그인을 이용해주세요.
-            </p>
-
-            <button
-              type="button"
-              onClick={() => setSocialProviderName('')}
               className="mt-6 h-12 w-full rounded-[16px] text-[15px] font-semibold text-white transition-all hover:-translate-y-0.5"
               style={{
                 background:

--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -25,7 +25,13 @@ export default function ProfileScreen() {
   const [showPassword, setShowPassword] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [showSaveToast, setShowSaveToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState('프로필 정보가 저장되었습니다');
+  const [isSaving, setIsSaving] = useState(false);
   const [profileImage, setProfileImage] = useState<string | null>(null);
+  const [savedProfileImage, setSavedProfileImage] = useState<string | null>(null);
+  const [selectedProfileFile, setSelectedProfileFile] = useState<File | null>(null);
+  const [profileImageDeleted, setProfileImageDeleted] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
 
   const [user, setUser] = useState({
     name: '',
@@ -34,9 +40,51 @@ export default function ProfileScreen() {
     createdAt: '',
   });
 
+  const [savedUser, setSavedUser] = useState(user);
+
+  const showToast = (message: string) => {
+    setToastMessage(message);
+    setShowSaveToast(true);
+    window.setTimeout(() => {
+      setShowSaveToast(false);
+    }, 1800);
+  };
+
+  const getErrorMessage = (error: any, fallback: string) => {
+    return (
+      error?.response?.data?.detail ||
+      error?.response?.data?.message ||
+      fallback
+    );
+  };
+
+  const patchWithFallbackPayloads = async (
+    url: string,
+    payloads: Array<Record<string, string>>,
+  ) => {
+    let lastError: unknown;
+
+    for (const payload of payloads) {
+      try {
+        return await client.patch(url, payload);
+      } catch (error: any) {
+        lastError = error;
+
+        if (![400, 422].includes(error?.response?.status)) {
+          throw error;
+        }
+      }
+    }
+
+    throw lastError;
+  };
+
   useEffect(() => {
     const savedImage = localStorage.getItem('profileImage');
-    if (savedImage) setProfileImage(savedImage);
+    if (savedImage) {
+      setProfileImage(savedImage);
+      setSavedProfileImage(savedImage);
+    }
 
     const fetchUserInfo = async () => {
       try {
@@ -48,10 +96,18 @@ export default function ProfileScreen() {
           password: '',
           createdAt: res.data.created_at || res.data.createdAt || '',
         });
+        setSavedUser({
+          name: res.data.nickname || res.data.name || '사용자',
+          email: res.data.email || '',
+          password: '',
+          createdAt: res.data.created_at || res.data.createdAt || '',
+        });
 
         const serverImage = res.data.profile_image || res.data.profileImage;
         if (serverImage) {
           setProfileImage(serverImage);
+          setSavedProfileImage(serverImage);
+          localStorage.setItem('profileImage', serverImage);
         }
       } catch (error) {
         console.error('유저 정보 불러오기 실패:', error);
@@ -59,6 +115,12 @@ export default function ProfileScreen() {
         if (stored) {
           const u = JSON.parse(stored);
           setUser({
+            name: u.nickname || u.name || '사용자',
+            email: u.email || '',
+            password: '',
+            createdAt: u.created_at || u.createdAt || '',
+          });
+          setSavedUser({
             name: u.nickname || u.name || '사용자',
             email: u.email || '',
             password: '',
@@ -75,6 +137,9 @@ export default function ProfileScreen() {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    setSelectedProfileFile(file);
+    setProfileImageDeleted(false);
+
     const reader = new FileReader();
     reader.onload = () => {
       setProfileImage(reader.result as string);
@@ -84,34 +149,133 @@ export default function ProfileScreen() {
 
   const handleResetImage = () => {
     setProfileImage(null);
+    setSelectedProfileFile(null);
+    setProfileImageDeleted(true);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
   };
 
-  const handleSave = () => {
+  const syncStoredUserInfo = (nextNickname: string) => {
     const stored = localStorage.getItem('userInfo');
     const userInfo = stored ? JSON.parse(stored) : {};
-    userInfo.nickname = user.name;
+
+    userInfo.nickname = nextNickname;
+    userInfo.name = nextNickname;
+    userInfo.email = user.email || userInfo.email;
+
     localStorage.setItem('userInfo', JSON.stringify(userInfo));
+  };
 
-    if (profileImage) {
-      localStorage.setItem('profileImage', profileImage);
-    } else {
-      localStorage.removeItem('profileImage');
+  const uploadProfileImage = async (file: File) => {
+    const formData = new FormData();
+
+    formData.append('file', file);
+
+    return client.post('/api/v1/auth/me/profile-image', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  };
+
+  const handleSave = async () => {
+    if (isSaving) return;
+
+    try {
+      setIsSaving(true);
+
+      const nextName = user.name.trim();
+
+      if (!nextName) {
+        showToast('닉네임을 입력해주세요.');
+        return;
+      }
+
+      if (nextName !== savedUser.name) {
+        await patchWithFallbackPayloads('/api/v1/auth/me/nickname', [
+          { nickname: nextName },
+          { name: nextName },
+        ]);
+      }
+
+      if (currentPassword.trim() || user.password.trim()) {
+        if (!currentPassword.trim() || !user.password.trim()) {
+          showToast('현재 비밀번호와 새 비밀번호를 모두 입력해주세요.');
+          return;
+        }
+
+        await client.patch('/api/v1/auth/me/password', {
+          current_password: currentPassword.trim(),
+          new_password: user.password.trim(),
+        });
+      }
+
+      if (selectedProfileFile) {
+        const response = await uploadProfileImage(selectedProfileFile);
+        const serverImage =
+          response.data?.profile_image ||
+          response.data?.profileImage ||
+          response.data?.url ||
+          response.data?.image_url;
+
+        if (serverImage) {
+          setProfileImage(serverImage);
+          setSavedProfileImage(serverImage);
+          localStorage.setItem('profileImage', serverImage);
+        } else if (profileImage) {
+          localStorage.setItem('profileImage', profileImage);
+          setSavedProfileImage(profileImage);
+        }
+      } else if (profileImageDeleted) {
+        await client.delete('/api/v1/auth/me/profile-image');
+        setSavedProfileImage(null);
+        localStorage.removeItem('profileImage');
+      } else if (profileImage) {
+        localStorage.setItem('profileImage', profileImage);
+        setSavedProfileImage(profileImage);
+      }
+
+      const nextUser = {
+        ...user,
+        name: nextName,
+        password: '',
+      };
+
+      setUser(nextUser);
+      setSavedUser(nextUser);
+      setCurrentPassword('');
+      syncStoredUserInfo(nextName);
+      setSelectedProfileFile(null);
+      setProfileImageDeleted(false);
+      setIsEdit(false);
+      showToast('프로필 정보가 저장되었습니다');
+    } catch (error: any) {
+      console.error('프로필 저장 실패:', error);
+      showToast(getErrorMessage(error, '프로필 저장에 실패했습니다.'));
+    } finally {
+      setIsSaving(false);
     }
+  };
 
+  const handleCancelEdit = () => {
+    setUser(savedUser);
+    setCurrentPassword('');
+    setProfileImage(savedProfileImage);
+    setSelectedProfileFile(null);
+    setProfileImageDeleted(false);
     setIsEdit(false);
-    setShowSaveToast(true);
-    setTimeout(() => {
-      setShowSaveToast(false);
-    }, 1800);
   };
 
   const handleLogout = () => {
     localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
     setShowLogoutModal(false);
     navigate('/login');
+  };
+
+  const handleAccountDeleteClick = () => {
+    showToast('회원 탈퇴 API가 아직 제공되지 않았습니다.');
   };
 
   const displayInitial = user.name ? user.name.charAt(0) : 'U';
@@ -145,9 +309,10 @@ export default function ProfileScreen() {
           <div className="flex w-[56px] items-center justify-end">
             <button
               onClick={() => (isEdit ? handleSave() : setIsEdit(true))}
-              className="text-[13px] font-semibold text-[#6C80DD] hover:opacity-80 sm:text-[14px]"
+              disabled={isSaving}
+              className="text-[13px] font-semibold text-[#6C80DD] hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50 sm:text-[14px]"
             >
-              {isEdit ? '저장' : '편집'}
+              {isSaving ? '저장 중' : isEdit ? '저장' : '편집'}
             </button>
           </div>
         </header>
@@ -159,7 +324,7 @@ export default function ProfileScreen() {
                 <div className="relative">
                   <button
                     type="button"
-                    onClick={() => fileInputRef.current?.click()}
+                    onClick={() => isEdit && fileInputRef.current?.click()}
                     className="group relative flex h-14 w-14 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-[#667AF2] to-[#8097F8] text-white shadow-sm"
                   >
                     {profileImage ? (
@@ -181,7 +346,8 @@ export default function ProfileScreen() {
 
                   <button
                     type="button"
-                    onClick={() => fileInputRef.current?.click()}
+                    onClick={() => isEdit && fileInputRef.current?.click()}
+                    disabled={!isEdit}
                     className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border border-white bg-[#EEF2FF] text-[#4C63D2] shadow-sm"
                     aria-label="프로필 사진 변경"
                   >
@@ -193,6 +359,7 @@ export default function ProfileScreen() {
                     type="file"
                     accept="image/*"
                     className="hidden"
+                    disabled={!isEdit}
                     onChange={handleImageChange}
                   />
                 </div>
@@ -261,7 +428,19 @@ export default function ProfileScreen() {
                 </div>
 
                 <div>
-                  <label className="text-[12px] text-slate-400">비밀번호</label>
+                  <label className="text-[12px] text-slate-400">현재 비밀번호</label>
+                  <input
+                    type={showPassword ? 'text' : 'password'}
+                    disabled={!isEdit}
+                    value={currentPassword}
+                    placeholder="현재 비밀번호 입력"
+                    onChange={(e) => setCurrentPassword(e.target.value)}
+                    className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-[14px] disabled:bg-slate-50"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-[12px] text-slate-400">새 비밀번호</label>
                   <div className="flex gap-2">
                     <input
                       type={showPassword ? 'text' : 'password'}
@@ -273,16 +452,17 @@ export default function ProfileScreen() {
                       }
                       className="flex-1 rounded-xl border border-slate-200 px-3 py-2.5 text-[14px]"
                     />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-white"
-                    >
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-white"
+                    aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                  >
                       {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                     </button>
                   </div>
                   <p className="mt-1.5 text-[11px] text-slate-400">
-                    비밀번호를 입력한 경우에만 변경됩니다.
+                    현재 비밀번호와 새 비밀번호를 모두 입력한 경우에만 변경됩니다.
                   </p>
                 </div>
               </div>
@@ -291,7 +471,8 @@ export default function ProfileScreen() {
                 <div className="flex gap-2 border-t border-slate-100 p-4">
                   <button
                     type="button"
-                    onClick={() => setIsEdit(false)}
+                    onClick={handleCancelEdit}
+                    disabled={isSaving}
                     className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-[13px] font-semibold text-slate-600"
                   >
                     취소
@@ -300,13 +481,14 @@ export default function ProfileScreen() {
                   <button
                     type="button"
                     onClick={handleSave}
+                    disabled={isSaving}
                     style={{
                       backgroundColor: '#EEF2FF',
                       color: '#4C63D2',
                     }}
                     className="flex-1 rounded-xl py-2.5 text-[13px] font-semibold shadow-sm transition"
                   >
-                    저장
+                    {isSaving ? '저장 중...' : '저장'}
                   </button>
                 </div>
               )}
@@ -426,6 +608,7 @@ export default function ProfileScreen() {
 
                 <button
                   type="button"
+                  onClick={handleAccountDeleteClick}
                   className="flex w-full items-center gap-4 rounded-2xl border border-red-100 bg-white px-5 py-4 text-left transition hover:bg-[#FFF7F7] sm:gap-5 sm:px-6 sm:py-5"
                 >
                   <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#FFF5F5]">
@@ -518,7 +701,7 @@ export default function ProfileScreen() {
       {showSaveToast && (
         <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 px-4">
           <div className="rounded-full border border-white/80 bg-slate-900/85 px-5 py-3 text-[13px] font-medium text-white shadow-lg backdrop-blur sm:text-[14px]">
-            프로필 정보가 저장되었습니다
+            {toastMessage}
           </div>
         </div>
       )}

--- a/src/app/screens/ResultDashboard.tsx
+++ b/src/app/screens/ResultDashboard.tsx
@@ -54,6 +54,8 @@ type AnalysisResult = {
   analyzedDate: string;
   safetyScore: number;
   contractType: string;
+  contractStartDate: string;
+  contractEndDate: string;
   contractPeriod: string;
   contractPeriodDetail: string;
   salary: string;
@@ -73,6 +75,8 @@ const DEFAULT_ANALYSIS: AnalysisResult = {
   analyzedDate: '분석 완료',
   safetyScore: 0,
   contractType: 'unknown',
+  contractStartDate: '-',
+  contractEndDate: '-',
   contractPeriod: '-',
   contractPeriodDetail: '-',
   salary: '-',
@@ -149,6 +153,35 @@ function toNum(raw: unknown): number | null {
   return Number.isFinite(n) && n > 0 ? n : null;
 }
 
+function cleanMoneyText(value: string) {
+  if (!value || value === '-') return value;
+
+  const normalized = value
+    .replace(/^금\s*/u, '')
+    .replace(/\(\s*/gu, '')
+    .replace(/\s*\)/gu, '')
+    .replace(/\s*원\s*정\b/gu, '원')
+    .replace(/\s+정$/u, '')
+    .trim();
+
+  const numericOnly = normalized.replace(/,/g, '').trim();
+
+  if (/^\d+$/.test(numericOnly)) {
+    return `${new Intl.NumberFormat('ko-KR').format(Number(numericOnly))}원`;
+  }
+
+  const numericWonMatch = normalized.match(/(\d[\d,]*)\s*원/u);
+  if (numericWonMatch) {
+    const amount = Number(numericWonMatch[1].replace(/,/g, ''));
+
+    if (Number.isFinite(amount)) {
+      return `${new Intl.NumberFormat('ko-KR').format(amount)}원`;
+    }
+  }
+
+  return normalized;
+}
+
 function normalizeAnalysis(data: any): AnalysisResult {
   const keyInfo = data?.analysis?.key_info ?? {};
 
@@ -189,6 +222,16 @@ function normalizeAnalysis(data: any): AnalysisResult {
     ),
     safetyScore:
       Number(data?.safety_score ?? data?.analysis?.safety_score ?? calculatedScore) || 0,
+    contractStartDate: getKeyInfoValue(
+      keyInfo,
+      ['start_date', 'contract_start_date', 'contractStartDate', 'period_start', '시작일', '계약시작일'],
+      '-',
+    ),
+    contractEndDate: getKeyInfoValue(
+      keyInfo,
+      ['end_date', 'contract_end_date', 'contractEndDate', 'period_end', '종료일', '계약종료일', '만료일'],
+      '-',
+    ),
     contractPeriod: getKeyInfoValue(
       keyInfo,
       [
@@ -208,26 +251,30 @@ function normalizeAnalysis(data: any): AnalysisResult {
       ['end_date', 'contract_period_detail', 'contractPeriodDetail', 'period_detail', '계약기간상세'],
       '계약서 기준',
     ),
-    salary: getKeyInfoValue(
-      keyInfo,
-      [
-        'amount_text',
-        'amount_value',
-        'salary',
-        'monthly_salary',
-        'monthlySalary',
-        'wage',
-        'pay',
-        '급여',
-        '월급',
-        '임금',
-      ],
-      '-',
+    salary: cleanMoneyText(
+      getKeyInfoValue(
+        keyInfo,
+        [
+          'amount_text',
+          'amount_value',
+          'salary',
+          'monthly_salary',
+          'monthlySalary',
+          'wage',
+          'pay',
+          '급여',
+          '월급',
+          '임금',
+        ],
+        '-',
+      ),
     ),
-    salaryDetail: getKeyInfoValue(
-      keyInfo,
-      ['amount_value', 'salary_detail', 'salaryDetail', 'wage_detail', '급여상세'],
-      '계약서 기준',
+    salaryDetail: cleanMoneyText(
+      getKeyInfoValue(
+        keyInfo,
+        ['amount_value', 'salary_detail', 'salaryDetail', 'wage_detail', '급여상세'],
+        '계약서 기준',
+      ),
     ),
     summaryText:
       data?.analysis?.summary ?? data?.summary ?? '계약서 분석 결과를 확인해보세요.',
@@ -912,6 +959,9 @@ export function ResultDashboard() {
   const SummaryCards = () => {
     const hasWageBreakdown =
       analysis.hourlyWage || analysis.weeklyWorkHours || analysis.monthlyWage;
+    const hasStartDate = analysis.contractStartDate !== '-';
+    const hasEndDate = analysis.contractEndDate !== '-';
+    const hasSeparatedContractPeriod = hasStartDate || hasEndDate;
 
     const weeklyHolidayHours =
       analysis.weeklyWorkHours && analysis.weeklyWorkHours >= 15
@@ -935,29 +985,51 @@ export function ResultDashboard() {
                 <span className="block text-[13px] font-medium text-slate-500">
                   계약 기간
                 </span>
-                <div className="mt-2 break-words text-[20px] font-semibold tracking-[-0.04em] text-slate-900">
-                  {analysis.contractPeriod}
-                </div>
-                <p className="mt-1 text-[12px] leading-5 text-slate-500">
-                  {analysis.contractPeriodDetail}
+                {hasSeparatedContractPeriod ? (
+                  <div className="mt-3 space-y-2">
+                    <div className="min-w-0 rounded-[14px] bg-slate-50 px-3 py-2 text-center">
+                      <span className="block text-[11px] font-semibold text-slate-400">
+                        시작일
+                      </span>
+                      <span className="mt-1 block break-words text-[16px] font-semibold text-slate-900">
+                        {analysis.contractStartDate}
+                      </span>
+                    </div>
+
+                    <div className="min-w-0 rounded-[14px] bg-slate-50 px-3 py-2 text-center">
+                      <span className="block text-[11px] font-semibold text-slate-400">
+                        종료일
+                      </span>
+                      <span className="mt-1 block break-words text-[16px] font-semibold text-slate-900">
+                        {analysis.contractEndDate}
+                      </span>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-2 break-words text-[18px] font-semibold tracking-[-0.02em] text-slate-900">
+                    {analysis.contractPeriod}
+                  </div>
+                )}
+                <p className="mt-2 text-[12px] leading-5 text-slate-500">
+                  {hasSeparatedContractPeriod ? '계약서에 명시된 시작일과 종료일이에요.' : analysis.contractPeriodDetail}
                 </p>
               </div>
             </div>
           </div>
 
           <div className="min-w-0 rounded-[20px] border border-slate-100 bg-white px-4 py-4 shadow-sm">
-            <div className="flex flex-col items-center text-center">
+            <div className="flex h-full min-h-[220px] flex-col items-center justify-center text-center">
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-emerald-50 text-emerald-600">
                 <DollarSign size={17} />
               </div>
 
-              <div className="mt-3 min-w-0">
+              <div className="mt-3 w-full min-w-0 text-center">
                 <span className="block text-[13px] font-medium text-slate-500">
                   {contractAmountLabel}
                 </span>
 
-                <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
-                  <span className="break-words text-center text-[20px] font-semibold tracking-[-0.04em] text-slate-900">
+                <div className="mt-2 flex w-full flex-wrap items-center justify-center gap-2 text-center">
+                  <span className="block max-w-full break-words text-center text-[20px] font-semibold tracking-[-0.04em] text-slate-900">
                     {contractAmount}
                   </span>
 
@@ -968,7 +1040,7 @@ export function ResultDashboard() {
                   )}
                 </div>
 
-                <p className="mt-1 text-[12px] leading-5 text-slate-500">
+                <p className="mx-auto mt-1 max-w-full break-words text-center text-[12px] leading-5 text-slate-500">
                   {analysis.monthlyWageIsEstimated
                     ? '시간급 기반으로 계산한 추정 금액이에요.'
                     : analysis.salaryDetail}

--- a/src/app/screens/SignUp.tsx
+++ b/src/app/screens/SignUp.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, X, Mail, ShieldCheck } from 'lucide-react';
 import client from '../../api/client';
+import { redirectToSocialLogin, type SocialProvider } from '../../api/socialAuth';
 
 export function SignUp() {
   const navigate = useNavigate();
@@ -27,7 +28,6 @@ export function SignUp() {
   const [isSignUpSuccessOpen, setIsSignUpSuccessOpen] = useState(false);
   const [isSignUpErrorOpen, setIsSignUpErrorOpen] = useState(false);
   const [isTermsRequiredOpen, setIsTermsRequiredOpen] = useState(false);
-  const [socialProviderName, setSocialProviderName] = useState('');
 
   useEffect(() => {
     if (cooldown <= 0) return;
@@ -53,14 +53,8 @@ export function SignUp() {
     navigate('/login');
   };
 
-  const handleSocialLogin = (provider: 'google' | 'naver' | 'kakao') => {
-    const providerNames = {
-      google: 'Google',
-      naver: 'Naver',
-      kakao: 'KakaoTalk',
-    };
-
-    setSocialProviderName(providerNames[provider]);
+  const handleSocialLogin = (provider: SocialProvider) => {
+    redirectToSocialLogin(provider);
   };
 
   const handleLogin = () => {
@@ -634,47 +628,6 @@ export function SignUp() {
         </div>
       )}
 
-      {socialProviderName && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/20 px-5 backdrop-blur-sm">
-          <div className="w-full max-w-[380px] rounded-[28px] border border-white/90 bg-white/95 px-6 py-7 text-center shadow-[0_24px_70px_rgba(95,117,177,0.24)]">
-            <button
-              type="button"
-              onClick={() => setSocialProviderName('')}
-              className="ml-auto flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
-              aria-label="닫기"
-            >
-              <X size={18} />
-            </button>
-
-            <div className="mx-auto mt-1 flex h-13 w-13 items-center justify-center rounded-full bg-[#EEF3FF] text-[24px] font-bold text-[#667AF2]">
-              !
-            </div>
-
-            <h2 className="mt-5 text-[21px] font-bold tracking-[-0.03em] text-slate-900">
-              소셜 가입을 준비 중이에요
-            </h2>
-
-            <p className="mt-2 text-[14px] leading-6 text-slate-500">
-              {socialProviderName} 계정 연동 설정이 아직 완료되지 않았어요.
-              <br />
-              지금은 이메일 회원가입을 이용해주세요.
-            </p>
-
-            <button
-              type="button"
-              onClick={() => setSocialProviderName('')}
-              className="mt-6 h-12 w-full rounded-[16px] text-[15px] font-semibold text-white transition-all hover:-translate-y-0.5"
-              style={{
-                background:
-                  'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
-                boxShadow: '0 14px 30px rgba(102,122,242,0.24)',
-              }}
-            >
-              확인
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/app/screens/StartScreen.tsx
+++ b/src/app/screens/StartScreen.tsx
@@ -1,60 +1,132 @@
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import client from '../../api/client';
+import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion';
+
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+};
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 28 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.58, ease: 'easeOut' as const } },
+};
+
+const analysisSignals = [
+  { label: '조항 스캔', value: '32개', width: '72%', color: 'bg-[#667AF2]' },
+  { label: '위험 탐지', value: '3건', width: '58%', color: 'bg-red-400' },
+  { label: '법령 대조', value: '진행 중', width: '84%', color: 'bg-amber-400' },
+];
+
+const insightChips = [
+  { label: '위험 조항 감지', value: '+3', className: '-left-10 top-24' },
+  { label: '근로기준법 대조', value: 'LIVE', className: 'right-2 top-[-20px]' },
+  { label: '요약 생성', value: 'AI', className: '-right-8 bottom-28' },
+];
 
 export function StartScreen() {
   const navigate = useNavigate();
+  const [activeSignal, setActiveSignal] = useState(0);
+  const previewX = useMotionValue(0);
+  const previewY = useMotionValue(0);
+  const cursorX = useMotionValue(-300);
+  const cursorY = useMotionValue(-300);
+  const previewXSpring = useSpring(previewX, { stiffness: 160, damping: 22 });
+  const previewYSpring = useSpring(previewY, { stiffness: 160, damping: 22 });
+  const cursorLeft = useSpring(cursorX, { stiffness: 80, damping: 24 });
+  const cursorTop = useSpring(cursorY, { stiffness: 80, damping: 24 });
+  const previewRotateX = useTransform(previewYSpring, [-0.5, 0.5], ['5deg', '-5deg']);
+  const previewRotateY = useTransform(previewXSpring, [-0.5, 0.5], ['-5deg', '5deg']);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setActiveSignal((prev) => (prev + 1) % analysisSignals.length);
+    }, 1400);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const handleRootMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    cursorX.set(event.clientX - 260);
+    cursorY.set(event.clientY - 140);
+  };
+
+  const handlePreviewMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+
+    previewX.set((event.clientX - rect.left) / rect.width - 0.5);
+    previewY.set((event.clientY - rect.top) / rect.height - 0.5);
+  };
+
+  const resetPreviewTilt = () => {
+    previewX.set(0);
+    previewY.set(0);
+  };
 
   return (
-    <div
-      className="min-h-screen overflow-hidden"
+    <motion.div
+      className="relative min-h-screen overflow-hidden"
       style={{
         background:
           'radial-gradient(circle at 18% 18%, rgba(95,117,177,0.15) 0%, rgba(95,117,177,0.06) 22%, transparent 46%), linear-gradient(180deg, #EEF2F9 0%, #FFFFFF 100%)',
       }}
+      onMouseMove={handleRootMove}
+      initial="hidden"
+      animate="visible"
+      variants={containerVariants}
     >
-      <div className="mx-auto flex min-h-screen max-w-[1480px] flex-col px-5 sm:px-8 md:px-10 lg:px-16 xl:px-24">
+      <motion.div
+        className="pointer-events-none absolute z-0 hidden h-[280px] w-[520px] rounded-[48px] bg-[linear-gradient(115deg,rgba(102,122,242,0)_0%,rgba(102,122,242,0.12)_46%,rgba(128,151,248,0.08)_62%,rgba(102,122,242,0)_100%)] blur-2xl lg:block"
+        style={{ left: cursorLeft, top: cursorTop }}
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-screen max-w-[1480px] flex-col px-5 sm:px-8 md:px-10 lg:px-16 xl:px-24">
         {/* Header */}
-        <header className="flex h-18 items-center justify-between py-4 sm:h-20 sm:py-0">
-          <button
+        <motion.header variants={fadeUp} className="flex h-18 items-center justify-between py-4 sm:h-20 sm:py-0">
+          <motion.button
             type="button"
             onClick={() => navigate('/')}
             className="text-[18px] font-medium tracking-[0.18em] text-slate-700 transition-opacity hover:opacity-80 sm:text-[22px] lg:text-[24px]"
+            whileHover={{ y: -1 }}
+            whileTap={{ scale: 0.98 }}
           >
             CLAIR.
-          </button>
+          </motion.button>
 
-          <button
+          <motion.button
             type="button"
             onClick={() => navigate('/login')}
             className="inline-flex h-10 min-w-[88px] items-center justify-center rounded-[14px] border border-slate-200/80 bg-white/90 px-4 text-[14px] font-semibold text-slate-700 shadow-sm backdrop-blur transition-all hover:-translate-y-0.5 hover:border-slate-300 hover:bg-white hover:text-slate-950 sm:h-11 sm:min-w-[96px] sm:text-[15px]"
+            whileHover={{ y: -2 }}
+            whileTap={{ scale: 0.97 }}
           >
             로그인
-          </button>
-        </header>
+          </motion.button>
+        </motion.header>
 
         {/* Main */}
         <main className="flex flex-1 items-center py-4 sm:py-8 lg:py-0">
           <section className="grid w-full items-center gap-8 sm:gap-10 md:gap-12 lg:grid-cols-[minmax(0,0.98fr)_minmax(620px,1.02fr)] lg:gap-16 xl:gap-24">
             {/* Left */}
-            <div className="mx-auto w-full max-w-[610px] lg:mx-0">
-              <div className="mb-4 inline-flex items-center rounded-full border border-white/90 bg-white/82 px-4 py-2 text-[12px] font-medium text-slate-500 shadow-sm backdrop-blur sm:mb-6 sm:px-5 sm:py-2.5 sm:text-[13px]">
+            <motion.div variants={containerVariants} className="mx-auto w-full max-w-[610px] lg:mx-0">
+              <motion.div variants={fadeUp} className="mb-4 inline-flex items-center rounded-full border border-white/90 bg-white/82 px-4 py-2 text-[12px] font-medium text-slate-500 shadow-sm backdrop-blur sm:mb-6 sm:px-5 sm:py-2.5 sm:text-[13px]">
                 Smart Contract Review
-              </div>
+              </motion.div>
 
-              <h1 className="text-[36px] font-semibold leading-[1.06] tracking-[-0.05em] text-slate-950 sm:text-[46px] md:text-[54px] lg:text-[64px] xl:text-[80px]">
+              <motion.h1 variants={fadeUp} className="text-[36px] font-semibold leading-[1.06] tracking-[-0.05em] text-slate-950 sm:text-[46px] md:text-[54px] lg:text-[64px] xl:text-[80px]">
                 계약을 더
                 <br />
                 안전하고 명확하게
-              </h1>
+              </motion.h1>
 
-              <p className="mt-4 max-w-[530px] text-[15px] leading-7 text-slate-500 sm:mt-5 sm:text-[16px] sm:leading-8 md:text-[17px] lg:mt-8 lg:text-[19px] lg:leading-9">
+              <motion.p variants={fadeUp} className="mt-4 max-w-[530px] text-[15px] leading-7 text-slate-500 sm:mt-5 sm:text-[16px] sm:leading-8 md:text-[17px] lg:mt-8 lg:text-[19px] lg:leading-9">
                 복잡한 계약서를 빠르게 분석하고,
                 <br />
                 놓치기 쉬운 위험 조항을 한눈에 확인할 수 있도록 도와줍니다.
-              </p>
+              </motion.p>
 
-              <div className="mt-6 flex flex-col gap-3 sm:mt-8 sm:flex-row sm:items-center sm:gap-4 lg:mt-12">
-                <button
+              <motion.div variants={fadeUp} className="mt-6 flex flex-col gap-3 sm:mt-8 sm:flex-row sm:items-center sm:gap-4 lg:mt-12">
+                <motion.button
                   type="button"
                   onClick={() => navigate('/onboarding')}
                   className="inline-flex h-[50px] w-full items-center justify-center rounded-[16px] px-6 text-[15px] font-semibold text-white transition-all hover:-translate-y-0.5 sm:h-[56px] sm:w-auto sm:min-w-[170px] sm:text-[16px] lg:h-[68px] lg:min-w-[210px] lg:rounded-[24px] lg:px-10 lg:text-[18px]"
@@ -63,48 +135,52 @@ export function StartScreen() {
                       'linear-gradient(135deg, #667AF2 0%, #8097F8 100%)',
                     boxShadow: '0 18px 38px rgba(102,122,242,0.26)',
                   }}
+                  whileHover={{ y: -4, scale: 1.015, boxShadow: '0 24px 48px rgba(102,122,242,0.34)' }}
+                  whileTap={{ scale: 0.97 }}
                 >
                   시작하기
-                </button>
+                </motion.button>
 
-                <button
+                <motion.button
                   type="button"
                   onClick={() => navigate('/login')}
                   className="inline-flex h-[50px] w-full items-center justify-center rounded-[16px] border border-slate-200/80 bg-white/92 px-6 text-[15px] font-semibold text-slate-700 shadow-sm backdrop-blur transition-all hover:-translate-y-0.5 hover:border-slate-300 hover:bg-white hover:text-slate-950 sm:h-[56px] sm:w-auto sm:min-w-[132px] sm:text-[16px] lg:h-[68px] lg:min-w-[158px] lg:rounded-[24px] lg:px-8 lg:text-[18px]"
+                  whileHover={{ y: -4, scale: 1.015 }}
+                  whileTap={{ scale: 0.97 }}
                 >
                   로그인
-                </button>
-              </div>
+                </motion.button>
+              </motion.div>
 
               {/* Mobile / Tablet feature cards */}
-              <div className="mt-7 grid grid-cols-3 gap-2 sm:mt-10 sm:gap-3 lg:mt-14 lg:gap-4">
-                <div className="rounded-[18px] border border-slate-200/70 bg-white/88 p-3 text-center shadow-sm backdrop-blur sm:rounded-[20px] sm:p-4 lg:rounded-[24px] lg:p-6">
+              <motion.div variants={fadeUp} className="mt-7 grid grid-cols-3 gap-2 sm:mt-10 sm:gap-3 lg:mt-14 lg:gap-4">
+                <motion.div whileHover={{ y: -5 }} className="rounded-[18px] border border-slate-200/70 bg-white/88 p-3 text-center shadow-sm backdrop-blur sm:rounded-[20px] sm:p-4 lg:rounded-[24px] lg:p-6">
                   <p className="text-[20px] font-semibold leading-none text-slate-900 sm:text-[24px] lg:text-[34px]">
                     Fast
                   </p>
                   <p className="mt-2 text-[11px] leading-5 text-slate-500 sm:mt-3 sm:text-[12px] lg:mt-4 lg:text-[14px] lg:leading-6">
                     빠른 계약 분석
                   </p>
-                </div>
+                </motion.div>
 
-                <div className="rounded-[18px] border border-slate-200/70 bg-white/88 p-3 text-center shadow-sm backdrop-blur sm:rounded-[20px] sm:p-4 lg:rounded-[24px] lg:p-6">
+                <motion.div whileHover={{ y: -5 }} className="rounded-[18px] border border-slate-200/70 bg-white/88 p-3 text-center shadow-sm backdrop-blur sm:rounded-[20px] sm:p-4 lg:rounded-[24px] lg:p-6">
                   <p className="text-[20px] font-semibold leading-none text-slate-900 sm:text-[24px] lg:text-[34px]">
                     Clear
                   </p>
                   <p className="mt-2 text-[11px] leading-5 text-slate-500 sm:mt-3 sm:text-[12px] lg:mt-4 lg:text-[14px] lg:leading-6">
                     명확한 리스크 표시
                   </p>
-                </div>
+                </motion.div>
 
-                <div className="rounded-[18px] border border-slate-200/70 bg-white/88 p-3 text-center shadow-sm backdrop-blur sm:rounded-[20px] sm:p-4 lg:rounded-[24px] lg:p-6">
+                <motion.div whileHover={{ y: -5 }} className="rounded-[18px] border border-slate-200/70 bg-white/88 p-3 text-center shadow-sm backdrop-blur sm:rounded-[20px] sm:p-4 lg:rounded-[24px] lg:p-6">
                   <p className="text-[20px] font-semibold leading-none text-slate-900 sm:text-[24px] lg:text-[34px]">
                     Safe
                   </p>
                   <p className="mt-2 text-[11px] leading-5 text-slate-500 sm:mt-3 sm:text-[12px] lg:mt-4 lg:text-[14px] lg:leading-6">
                     안전한 계약 판단
                   </p>
-                </div>
-              </div>
+                </motion.div>
+              </motion.div>
 
               {/* Mobile / Tablet preview */}
               <div className="mt-6 block lg:hidden">
@@ -157,10 +233,51 @@ export function StartScreen() {
                   </div>
                 </div>
               </div>
-            </div>
+            </motion.div>
 
             {/* Desktop preview only */}
-            <div className="relative mx-auto hidden w-full max-w-[820px] lg:block">
+            <motion.div
+              variants={fadeUp}
+              className="relative mx-auto hidden w-full max-w-[820px] lg:block"
+              onMouseMove={handlePreviewMove}
+              onMouseLeave={resetPreviewTilt}
+              style={{
+                rotateX: previewRotateX,
+                rotateY: previewRotateY,
+                transformStyle: 'preserve-3d',
+                perspective: 1000,
+              }}
+            >
+              {insightChips.map((chip, index) => (
+                <motion.div
+                  key={chip.label}
+                  className={`pointer-events-none absolute z-20 hidden rounded-[18px] border border-white/90 bg-white/88 px-4 py-3 shadow-[0_18px_44px_rgba(15,23,42,0.12)] backdrop-blur-xl xl:block ${chip.className}`}
+                  initial={{ opacity: 0, y: 18, scale: 0.92 }}
+                  animate={{
+                    opacity: 1,
+                    y: [0, -8, 0],
+                    scale: 1,
+                  }}
+                  transition={{
+                    opacity: { duration: 0.45, delay: 0.5 + index * 0.16 },
+                    scale: { duration: 0.45, delay: 0.5 + index * 0.16 },
+                    y: {
+                      duration: 3.2 + index * 0.4,
+                      repeat: Infinity,
+                      ease: 'easeInOut',
+                      delay: index * 0.35,
+                    },
+                  }}
+                >
+                  <span className="block text-[11px] font-medium text-slate-400">
+                    {chip.label}
+                  </span>
+                  <span className="mt-0.5 block text-[15px] font-semibold text-slate-900">
+                    {chip.value}
+                  </span>
+                </motion.div>
+              ))}
+
               <div
                 className="absolute -left-12 top-10 h-52 w-52 rounded-full blur-3xl"
                 style={{ backgroundColor: 'rgba(95,117,177,0.18)' }}
@@ -170,9 +287,10 @@ export function StartScreen() {
                 style={{ backgroundColor: 'rgba(125,149,246,0.16)' }}
               />
 
-              <div
+              <motion.div
                 className="relative rounded-[40px] border border-white/90 bg-white/82 p-6 backdrop-blur"
                 style={{ boxShadow: '0 34px 100px rgba(15,23,42,0.12)' }}
+                whileHover={{ y: -6, boxShadow: '0 42px 110px rgba(15,23,42,0.16)' }}
               >
                 <div className="mb-5 flex items-center justify-between rounded-[20px] bg-slate-50/95 px-5 py-4">
                   <div className="flex items-center gap-3">
@@ -191,7 +309,12 @@ export function StartScreen() {
 
                 <div className="grid gap-5 md:grid-cols-[1fr_220px]">
                   <div className="space-y-4">
-                    <div className="rounded-[24px] bg-slate-50/90 p-6">
+                    <div className="relative overflow-hidden rounded-[24px] bg-slate-50/90 p-6">
+                      <motion.div
+                        className="pointer-events-none absolute left-0 top-0 h-full w-20 bg-gradient-to-r from-transparent via-white/75 to-transparent"
+                        animate={{ x: [-90, 560] }}
+                        transition={{ duration: 3.6, repeat: Infinity, ease: 'easeInOut' }}
+                      />
                       <div className="space-y-3.5">
                         <div className="h-3.5 w-36 rounded-full bg-slate-200" />
                         <div className="h-3.5 w-full rounded-full bg-slate-100" />
@@ -201,7 +324,7 @@ export function StartScreen() {
                     </div>
 
                     <div className="space-y-3">
-                      <div className="rounded-[22px] border border-slate-200/70 bg-white/96 p-4 shadow-sm">
+                      <motion.div whileHover={{ x: 6, y: -2 }} className="rounded-[22px] border border-slate-200/70 bg-white/96 p-4 shadow-sm">
                         <div className="flex items-start gap-3">
                           <div className="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-red-100 text-[11px] font-semibold text-red-400">
                             1
@@ -217,9 +340,9 @@ export function StartScreen() {
                             </p>
                           </div>
                         </div>
-                      </div>
+                      </motion.div>
 
-                      <div className="rounded-[22px] border border-slate-200/70 bg-white/96 p-4 shadow-sm">
+                      <motion.div whileHover={{ x: 6, y: -2 }} className="rounded-[22px] border border-slate-200/70 bg-white/96 p-4 shadow-sm">
                         <div className="flex items-start gap-3">
                           <div className="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-amber-100 text-[11px] font-semibold text-amber-500">
                             2
@@ -235,9 +358,9 @@ export function StartScreen() {
                             </p>
                           </div>
                         </div>
-                      </div>
+                      </motion.div>
 
-                      <div className="rounded-[22px] border border-slate-200/70 bg-white/96 p-4 shadow-sm">
+                      <motion.div whileHover={{ x: 6, y: -2 }} className="rounded-[22px] border border-slate-200/70 bg-white/96 p-4 shadow-sm">
                         <div className="flex items-start gap-3">
                           <div className="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-slate-200 text-[11px] font-semibold text-slate-500">
                             3
@@ -253,7 +376,7 @@ export function StartScreen() {
                             </p>
                           </div>
                         </div>
-                      </div>
+                      </motion.div>
                     </div>
                   </div>
 
@@ -267,41 +390,84 @@ export function StartScreen() {
                       </p>
 
                       <div className="mt-6 flex justify-center">
-                        <div
+                        <motion.div
                           className="relative flex h-[132px] w-[132px] items-center justify-center rounded-full"
                           style={{
                             background:
                               'conic-gradient(#7C90EA 0 65%, #E8EDFC 65% 100%)',
                           }}
+                          animate={{ rotate: [0, 2, 0, -2, 0] }}
+                          transition={{ duration: 5, repeat: Infinity, ease: 'easeInOut' }}
                         >
                           <div className="flex h-[96px] w-[96px] items-center justify-center rounded-full bg-white text-[36px] font-semibold text-slate-900">
                             65
                           </div>
-                        </div>
+                        </motion.div>
                       </div>
 
                       <div className="mt-6 rounded-[18px] bg-slate-50 px-4 py-4 text-center">
                         <p className="text-[11px] tracking-[0.28em] text-slate-300">
                           STATUS
                         </p>
-                        <p className="mt-1 text-[15px] font-medium text-slate-700">
-                          분석 진행 중
-                        </p>
+                        <motion.p
+                          key={analysisSignals[activeSignal].label}
+                          className="mt-1 text-[15px] font-medium text-slate-700"
+                          initial={{ opacity: 0, y: 8 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{ duration: 0.24 }}
+                        >
+                          {analysisSignals[activeSignal].label}
+                        </motion.p>
+                      </div>
+
+                      <div className="mt-4 space-y-3 rounded-[20px] border border-slate-100 bg-white px-4 py-4">
+                        {analysisSignals.map((signal, index) => {
+                          const isActive = activeSignal === index;
+
+                          return (
+                            <div key={signal.label}>
+                              <div className="flex items-center justify-between gap-3">
+                                <span
+                                  className={`text-[12px] font-medium ${
+                                    isActive ? 'text-slate-800' : 'text-slate-400'
+                                  }`}
+                                >
+                                  {signal.label}
+                                </span>
+                                <span
+                                  className={`text-[12px] font-semibold ${
+                                    isActive ? 'text-[#667AF2]' : 'text-slate-400'
+                                  }`}
+                                >
+                                  {signal.value}
+                                </span>
+                              </div>
+                              <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-slate-100">
+                                <motion.div
+                                  className={`h-full rounded-full ${signal.color}`}
+                                  initial={false}
+                                  animate={{ width: isActive ? signal.width : '24%' }}
+                                  transition={{ duration: 0.45, ease: 'easeOut' }}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              </motion.div>
 
               <p className="mx-auto mt-5 max-w-[560px] text-center text-[13px] leading-6 text-slate-400">
                 복잡한 계약서도 더 빠르고 안전하게 검토할 수 있도록
                 <br />
                 설계된 스마트 계약 분석 서비스
               </p>
-            </div>
+            </motion.div>
           </section>
         </main>
       </div>
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #96 

## 변경 사항

### 1. 소셜 로그인/회원가입 연결
- 로그인/회원가입 화면의 Google, Naver, Kakao 버튼을 백엔드 OAuth 시작 URL로 직접 연동했습니다.
  - Google: `${VITE_API_URL}/api/v1/auth/google`
  - Naver: `${VITE_API_URL}/api/v1/auth/naver`
  - Kakao: `${VITE_API_URL}/api/v1/auth/kakao`
- 기존의 임시 “소셜 로그인/가입 준비 중” 모달을 제거하고 공통 헬퍼 `src/api/socialAuth.ts`를 추가했습니다.

### 2. 분석 결과 화면 UI/UX 개선 (계약 기간 및 금액)
- **계약 기간 표시:** `start_date`, `end_date`를 각각 정규화하여 시작일과 종료일을 세로로 분리 배치하고 가운데 정렬하여 가독성을 높였습니다.
- **계약 금액 표시:** 계약서 원문식 표현(예: `금 사억오천만원 정`)을 제거하고 큰 금액과 보조 금액 모두 1,000원 단위 쉼표가 붙은 `450,000,000원` 형태로 포맷팅을 통일했습니다. 카드 내부 요소도 정중앙 정렬을 적용했습니다.

### 3. 시작화면(`StartScreen.tsx`) 인터랙션 강화
- 첫 진입 시 헤더, 문구, 버튼, 카드가 순차적으로 빌드업되는 애니메이션을 적용했습니다.
- 버튼 Hover/Tap 액션, 카드 반응형 효과, 3D 틸트 패널 및 마우스 트래킹 조명 효과를 추가했습니다.
- 스캔 라인 애니메이션, 떠다니는 분석 인사이트 칩, 진행 바 애니메이션을 더해 동적인 랜딩 페이지를 구현했습니다.

### 4. 프로필/설정 실제 API 연동
- 내 정보 조회(`GET /api/v1/auth/me`), 닉네임 변경(`PATCH /api/v1/auth/me/nickname`), 비밀번호 변경(`PATCH /api/v1/auth/me/password`), 프로필 이미지 수정/삭제(`POST`, `DELETE`) API를 연결했습니다.
- 로그아웃 처리 시 `accessToken`과 `refreshToken`이 모두 정상적으로 제거되도록 보완했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [x] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 각 기능 수정 후 `npm run build` 정상 실행 및 빌드 성공 확인 (Vite chunk size 경고 외 오류 없음)
- [x] 소셜 로그인 링크 이동 및 프로필 API 수정 기능 로컬 환경 검증 완료
- [x] 기존 기능 동작에 영향 없음 확인

## 리뷰어를 위한 참고 사항

### 1. 회원 탈퇴 예외 처리 관련
- 회원 탈퇴 API가 현재 백엔드 사양(OpenAPI)에 존재하지 않는 것을 확인했습니다.
- 이에 따라 회원 탈퇴 버튼 클릭 시 **"회원 탈퇴 API가 아직 제공되지 않았습니다."**라는 안내 토스트를 띄우도록 임시 예외 처리해 두었습니다. 백엔드 구현이 완료되면 추후 추가 연결할 예정입니다.

### 2. 📢 백엔드 팀 협업 요청 사항 (PDF 다운로드 기능 관련)
- 프론트엔드 화면에서는 금액 표시와 문구를 깔끔하게 정규화했으나, 다운로드 PDF는 프론트엔드가 생성하지 않고 백엔드(`/api/v1/contracts/{contract_id}/download/pdf`)에서 받아온 blob을 그대로 저장하고 있습니다.
- 따라서 PDF 파일 내부에서도 통일감 있는 UI를 제공할 수 있도록 **백엔드 PDF 생성 로직에서 아래 사항들을 반영해 주시길 요청드립니다.**
  - [ ] PDF 내 금액도 화면과 동일하게 `450,000,000원` 형태로 표시 (원문 표현 제거)
  - [ ] 문구 변경: `보고서 생성` ➡️ `계약서 생성`
  - [ ] 문구 변경: `계약서 생성일` ➡️ `계약 체결일` (`분석일` 문구는 유지)