### PR TITLE
feat: 회원가입 비밀번호 검증 추가 및 프로필 UI/UX 개선

### DIFF
--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -32,6 +32,7 @@ export default function ProfileScreen() {
   const [selectedProfileFile, setSelectedProfileFile] = useState<File | null>(null);
   const [profileImageDeleted, setProfileImageDeleted] = useState(false);
   const [currentPassword, setCurrentPassword] = useState('');
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
 
   const [user, setUser] = useState({
     name: '',
@@ -199,9 +200,22 @@ export default function ProfileScreen() {
         ]);
       }
 
-      if (currentPassword.trim() || user.password.trim()) {
-        if (!currentPassword.trim() || !user.password.trim()) {
-          showToast('현재 비밀번호와 새 비밀번호를 모두 입력해주세요.');
+      const hasPasswordChange =
+        currentPassword.trim() || user.password.trim() || newPasswordConfirm.trim();
+
+      if (hasPasswordChange) {
+        if (!currentPassword.trim() || !user.password.trim() || !newPasswordConfirm.trim()) {
+          showToast('현재 비밀번호, 새 비밀번호, 새 비밀번호 확인을 모두 입력해주세요.');
+          return;
+        }
+
+        if (user.password.trim().length < 8) {
+          showToast('새 비밀번호는 8자 이상이어야 합니다.');
+          return;
+        }
+
+        if (user.password.trim() !== newPasswordConfirm.trim()) {
+          showToast('새 비밀번호가 일치하지 않습니다.');
           return;
         }
 
@@ -245,6 +259,7 @@ export default function ProfileScreen() {
       setUser(nextUser);
       setSavedUser(nextUser);
       setCurrentPassword('');
+      setNewPasswordConfirm('');
       syncStoredUserInfo(nextName);
       setSelectedProfileFile(null);
       setProfileImageDeleted(false);
@@ -261,6 +276,7 @@ export default function ProfileScreen() {
   const handleCancelEdit = () => {
     setUser(savedUser);
     setCurrentPassword('');
+    setNewPasswordConfirm('');
     setProfileImage(savedProfileImage);
     setSelectedProfileFile(null);
     setProfileImageDeleted(false);
@@ -459,10 +475,25 @@ export default function ProfileScreen() {
                     aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
                   >
                       {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                    </button>
+                  </button>
                   </div>
                   <p className="mt-1.5 text-[11px] text-slate-400">
-                    현재 비밀번호와 새 비밀번호를 모두 입력한 경우에만 변경됩니다.
+                    새 비밀번호는 8자 이상으로 입력해주세요.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="text-[12px] text-slate-400">새 비밀번호 확인</label>
+                  <input
+                    type={showPassword ? 'text' : 'password'}
+                    disabled={!isEdit}
+                    value={newPasswordConfirm}
+                    placeholder="새 비밀번호를 다시 입력"
+                    onChange={(e) => setNewPasswordConfirm(e.target.value)}
+                    className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-[14px] disabled:bg-slate-50"
+                  />
+                  <p className="mt-1.5 text-[11px] text-slate-400">
+                    현재 비밀번호가 맞고 두 새 비밀번호가 일치하면 변경됩니다.
                   </p>
                 </div>
               </div>
@@ -496,7 +527,7 @@ export default function ProfileScreen() {
 
             <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
               <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EEF2FF]">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-[#EEF2FF]">
                   <Shield className="h-5 w-5 text-[#6C80DD]" />
                 </div>
 
@@ -511,32 +542,59 @@ export default function ProfileScreen() {
               </div>
 
               <div className="mt-4 overflow-hidden rounded-2xl border border-slate-100 bg-white">
-                <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
-                  <Mail className="h-4 w-4 text-slate-500" />
-                  <span className="flex-1 text-[13px] font-medium text-slate-800">
-                    이메일 인증
-                  </span>
-                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
+                <div className="flex items-center gap-4 border-b border-slate-100 px-5 py-4">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
+                    <Mail className="h-4 w-4 text-slate-600" />
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      이메일 인증
+                    </p>
+                    <p className="mt-1 truncate text-[12px] leading-5 text-slate-400">
+                      {user.email || '이메일 정보 없음'}
+                    </p>
+                  </div>
+
+                  <span className="shrink-0 rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
                     인증 완료
                   </span>
                 </div>
 
-                <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-3">
-                  <User className="h-4 w-4 text-slate-500" />
-                  <span className="flex-1 text-[13px] font-medium text-slate-800">
-                    계정 상태
-                  </span>
-                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
+                <div className="flex items-center gap-4 border-b border-slate-100 px-5 py-4">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
+                    <User className="h-4 w-4 text-slate-600" />
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      계정 상태
+                    </p>
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      CLAIR 계정을 정상적으로 이용 중입니다.
+                    </p>
+                  </div>
+
+                  <span className="shrink-0 rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-600">
                     활성
                   </span>
                 </div>
 
-                <div className="flex items-center gap-3 px-4 py-3">
-                  <Calendar className="h-4 w-4 text-slate-500" />
-                  <span className="flex-1 text-[13px] font-medium text-slate-800">
-                    가입일
-                  </span>
-                  <span className="text-[12px] text-slate-500">
+                <div className="flex items-center gap-4 px-5 py-4">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
+                    <Calendar className="h-4 w-4 text-slate-600" />
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[14px] font-semibold text-slate-900">
+                      가입일
+                    </p>
+                    <p className="mt-1 text-[12px] leading-5 text-slate-400">
+                      계정을 처음 만든 날짜입니다.
+                    </p>
+                  </div>
+
+                  <span className="shrink-0 text-[12px] font-medium text-slate-500">
                     {user.createdAt
                       ? new Date(user.createdAt).toLocaleDateString()
                       : '정보 없음'}
@@ -547,7 +605,7 @@ export default function ProfileScreen() {
 
             <section className="mt-4 rounded-[20px] border border-white/90 bg-white/90 p-4 shadow-sm backdrop-blur">
               <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EEF2FF]">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-[#EEF2FF]">
                   <KeyRound className="h-5 w-5 text-[#6C80DD]" />
                 </div>
 
@@ -561,17 +619,23 @@ export default function ProfileScreen() {
                 </div>
               </div>
 
-              <div className="mt-4 space-y-3">
-                <button
-                  type="button"
+              <div className="mt-4 overflow-hidden rounded-2xl border border-slate-100 bg-white">
+                <div
+                  role="button"
+                  tabIndex={0}
                   onClick={() => setIsEdit(true)}
-                  className="flex w-full items-center gap-4 rounded-2xl border border-slate-100 bg-white px-5 py-4 text-left transition hover:bg-[#F8FAFF] sm:gap-5 sm:px-6 sm:py-5"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      setIsEdit(true);
+                    }
+                  }}
+                  className="flex cursor-pointer items-center gap-4 border-b border-slate-100 px-5 py-4 transition hover:bg-[#F8FAFF]"
                 >
                   <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
                     <KeyRound className="h-4 w-4 text-slate-600" />
                   </div>
 
-                  <div className="flex-1">
+                  <div className="min-w-0 flex-1">
                     <p className="text-[14px] font-semibold text-slate-900">
                       비밀번호 변경
                     </p>
@@ -582,18 +646,24 @@ export default function ProfileScreen() {
                   </div>
 
                   <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
-                </button>
+                </div>
 
-                <button
-                  type="button"
+                <div
+                  role="button"
+                  tabIndex={0}
                   onClick={() => setShowLogoutModal(true)}
-                  className="flex w-full items-center gap-4 rounded-2xl border border-slate-100 bg-white px-5 py-4 text-left transition hover:bg-[#F8FAFF] sm:gap-5 sm:px-6 sm:py-5"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      setShowLogoutModal(true);
+                    }
+                  }}
+                  className="flex cursor-pointer items-center gap-4 border-b border-slate-100 px-5 py-4 transition hover:bg-[#F8FAFF]"
                 >
                   <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F8FAFF]">
                     <LogOut className="h-4 w-4 text-slate-600" />
                   </div>
 
-                  <div className="flex-1">
+                  <div className="min-w-0 flex-1">
                     <p className="text-[14px] font-semibold text-slate-900">
                       로그아웃
                     </p>
@@ -604,18 +674,24 @@ export default function ProfileScreen() {
                   </div>
 
                   <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
-                </button>
+                </div>
 
-                <button
-                  type="button"
+                <div
+                  role="button"
+                  tabIndex={0}
                   onClick={handleAccountDeleteClick}
-                  className="flex w-full items-center gap-4 rounded-2xl border border-red-100 bg-white px-5 py-4 text-left transition hover:bg-[#FFF7F7] sm:gap-5 sm:px-6 sm:py-5"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      handleAccountDeleteClick();
+                    }
+                  }}
+                  className="flex cursor-pointer items-center gap-4 px-5 py-4 transition hover:bg-[#FFF7F7]"
                 >
                   <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#FFF5F5]">
                     <AlertTriangle className="h-4 w-4 text-red-400" />
                   </div>
 
-                  <div className="flex-1">
+                  <div className="min-w-0 flex-1">
                     <p className="text-[14px] font-semibold text-slate-900">
                       계정 탈퇴
                     </p>
@@ -626,27 +702,9 @@ export default function ProfileScreen() {
                   </div>
 
                   <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" />
-                </button>
+                </div>
               </div>
             </section>
-
-            <div className="mt-5 border-t border-slate-200/70 pt-4 text-center">
-              <button
-                type="button"
-                onClick={() => setShowLogoutModal(true)}
-                style={{
-                  backgroundColor: '#EEF2FF',
-                  color: '#4C63D2',
-                }}
-                className="w-full rounded-2xl px-4 py-3 text-[14px] font-semibold shadow-sm transition hover:opacity-90"
-              >
-                로그아웃
-              </button>
-
-              <p className="mt-2 text-[12px] text-slate-400">
-                현재 계정에서 로그아웃됩니다
-              </p>
-            </div>
           </div>
         </main>
       </div>

--- a/src/app/screens/SignUp.tsx
+++ b/src/app/screens/SignUp.tsx
@@ -167,6 +167,7 @@ export function SignUp() {
       !email.trim() ||
       !nickname.trim() ||
       !password.trim() ||
+      password.length < 8 ||
       !passwordCheck.trim() ||
       password !== passwordCheck
     ) {
@@ -397,6 +398,9 @@ export function SignUp() {
                     disabled={!emailVerified}
                     className="h-[52px] w-full rounded-[16px] border border-slate-200/80 bg-white/88 px-4 text-[15px] text-slate-800 outline-none placeholder:text-slate-400 focus:border-[#8097F8] disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 sm:h-[56px] sm:rounded-[18px] sm:text-[16px]"
                   />
+                  <p className="mt-2 text-left text-[12px] font-medium text-slate-400 sm:text-[13px]">
+                    비밀번호는 8자 이상이어야 합니다.
+                  </p>
                 </div>
 
                 <div className="mt-5 sm:mt-6">


### PR DESCRIPTION
## 관련 이슈
Closes #106 

## 변경 사항
이전 이슈에서 제안된 회원가입 보안 강화 및 프로필 화면의 UI/UX 파편화 문제를 해결했습니다.

1. **회원가입 화면 (`src/app/screens/SignUp.tsx`)**
   * 비밀번호 입력란 하단에 안내 문구(`비밀번호는 8자 이상이어야 합니다.`)를 추가했습니다.
   * 제출 시 비밀번호가 8자 미만(`password.length < 8`)일 경우 가입이 실패하도록 유효성 검증 로직을 도입했습니다.

2. **프로필 화면 비밀번호 변경 로직 고도화 (`src/app/screens/ProfileScreen.tsx`)**
   * '현재 비밀번호', '새 비밀번호', '새 비밀번호 확인'을 모두 받도록 필드를 확장하고 `newPasswordConfirm` 상태를 추가했습니다.
   * 삼중 검증 조건을 반영했습니다. (세 필드 중 하나라도 입력 시 전 필드 필수, 새 비밀번호 8자 이상, 새 비밀번호 일치 확인)
   * 저장 성공 또는 편집 취소 시 입력되었던 비밀번호 관련 상태값들을 일괄 초기화하도록 구현했습니다.

3. **프로필 화면 섹션 UI 통일 및 접근성 개선**
   * `계정 정보`와 `보안 관리` 섹션을 `섹션 헤더 + rounded-2xl border 리스트 박스 + 동일한 div row 구조`로 통일했습니다.
   * 보안 관리 행의 레이아웃, 패딩, 폰트 크기, 아이콘 박스 스타일을 계정 정보와 픽셀 단위로 일치시켰습니다.
   * `div` 구조를 유지하면서도 키보드 탐색 및 스크린 리더 지원을 위해 `role="button"`, `tabIndex={0}`, Enter/Space 키 핸들러(`onKeyDown`)를 적용했습니다.
   * 하단에 중복 배치되어 있던 로그아웃 버튼을 제거하고, 보안 관리 리스트 내부의 두 번째 행으로 통합했습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [ ] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [ ] 빌드/설정 변경 (`chore`)

## 테스트 체크리스트
- [x] 로컬 개발 환경에서 회원가입 및 프로필 화면 정상 기동 확인 (`npm run dev`)
- [x] 회원가입 8자 미만 제한 및 프로필 비밀번호 삼중 검증 validation 정상 동작 확인
- [x] 키보드 Tab 키 및 Enter/Space 키를 통한 보안 관리 메뉴 진입/액션 정상 작동 확인
- [x] 수정 후 프로덕션 빌드 정상 완료 확인 (`npm run build`)

## 리뷰어를 위한 참고 사항
* 보안 관리 리스트를 만들 때 `<button>` 태그 대신 `div` 구조를 사용했습니다. 버튼 태그 사용 시 브라우저 기본 스타일과 기존 전역 스타일 때문에 계정 정보(`div`)와 정렬을 완벽히 맞추기 까다로워, 구조를 통일하는 대신 `role="button"`과 키보드 이벤트 핸들러를 수동으로 바인딩하여 웹 접근성을 챙겼습니다. 이 부분에 키 누락이나 포커스 이동 시 어색한 점이 없는지 위주로 봐주시면 감사하겠습니다!