### PR TITLE
feat: 회원 탈퇴·삭제 이력 API 연결 및 로딩/분석 대시보드 UI/UX 종합 개선

### DIFF
--- a/src/app/screens/ContractManagementScreen.tsx
+++ b/src/app/screens/ContractManagementScreen.tsx
@@ -69,6 +69,15 @@ type RawContract = {
   deleted_at?: string;
 };
 
+type DeletedContractPayload = {
+  deleted_contracts?: RawContract[];
+  deletedContracts?: RawContract[];
+  history?: RawContract[];
+  contracts?: RawContract[];
+  items?: RawContract[];
+  data?: RawContract[];
+};
+
 function SectionCard({
   title,
   subtitle,
@@ -205,14 +214,7 @@ export default function ContractManagementScreen() {
   const navigate = useNavigate();
 
   const [contracts, setContracts] = useState<Contract[]>([]);
-  const [deletedContracts, setDeletedContracts] = useState<Contract[]>(() => {
-    try {
-      const stored = localStorage.getItem('deletedContracts');
-      return stored ? JSON.parse(stored) : [];
-    } catch {
-      return [];
-    }
-  });
+  const [deletedContracts, setDeletedContracts] = useState<Contract[]>([]);
   const [selectedContractId, setSelectedContractId] = useState<number | null>(null);
   const [search, setSearch] = useState('');
   const [showAllContracts, setShowAllContracts] = useState(false);
@@ -225,9 +227,11 @@ export default function ContractManagementScreen() {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
 
   const [loading, setLoading] = useState(false);
+  const [loadingDeleteHistory, setLoadingDeleteHistory] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [deleteHistoryError, setDeleteHistoryError] = useState('');
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
@@ -338,7 +342,8 @@ export default function ContractManagementScreen() {
     const source = raw.contract ?? raw.data?.contract ?? raw.data ?? raw;
     const analysisSource = raw.analysis ?? source.analysis ?? raw.data?.analysis;
     const id = source.id ?? source.contract_id ?? source.contractId ?? fallbackId;
-    const sortSource = source.updated_at ?? source.uploaded_at ?? source.created_at;
+    const sortSource =
+      source.deleted_at ?? source.updated_at ?? source.uploaded_at ?? source.created_at;
     const fileName =
       source.file_name ??
       source.filename ??
@@ -373,18 +378,47 @@ export default function ContractManagementScreen() {
     return [];
   };
 
+  const extractDeletedContractArray = (data: DeletedContractPayload | RawContract[]) => {
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data.deleted_contracts)) return data.deleted_contracts;
+    if (Array.isArray(data.deletedContracts)) return data.deletedContracts;
+    if (Array.isArray(data.history)) return data.history;
+    return extractContractArray(data);
+  };
+
   const extractUploadedContractId = (data: any): number | null => {
     const rawId =
-      data?.id ??
       data?.contract_id ??
       data?.contractId ??
-      data?.contract?.id ??
       data?.contract?.contract_id ??
+      data?.contract?.contractId ??
+      data?.contract?.id ??
+      data?.data?.contract_id ??
+      data?.data?.contractId ??
+      data?.data?.contract?.contract_id ??
+      data?.data?.contract?.contractId ??
+      data?.data?.contract?.id ??
       data?.data?.id ??
-      data?.data?.contract_id;
+      data?.id;
 
     const id = Number(rawId);
     return Number.isFinite(id) && id > 0 ? id : null;
+  };
+
+  const requestAnalysis = async (contractId: number) => {
+    try {
+      return await client.post(`/api/v1/contracts/${contractId}/analyze`, null, {
+        params: { force: true },
+      });
+    } catch (error: any) {
+      if (![404, 405, 422].includes(error?.response?.status)) {
+        throw error;
+      }
+
+      return client.post(`/api/v1/contracts/${contractId}/request-analysis`, null, {
+        params: { force: true },
+      });
+    }
   };
 
   const fetchContracts = useCallback(
@@ -439,9 +473,32 @@ export default function ContractManagementScreen() {
     }
   }, []);
 
+  const fetchDeletedContracts = useCallback(async () => {
+    try {
+      setLoadingDeleteHistory(true);
+      setDeleteHistoryError('');
+
+      const response = await client.get('/api/v1/contracts/deleted');
+      const list = extractDeletedContractArray(response.data)
+        .map((contract, index) => ({
+          ...normalizeContract(contract, index + 1),
+          status: '삭제됨' as ContractStatus,
+        }))
+        .sort((a, b) => b.sortTime - a.sortTime || b.id - a.id);
+
+      setDeletedContracts(list);
+    } catch (error) {
+      console.error('삭제 이력 조회 실패:', error);
+      setDeleteHistoryError('삭제 이력을 불러오지 못했어요. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setLoadingDeleteHistory(false);
+    }
+  }, []);
+
   useEffect(() => {
     fetchContracts();
-  }, [fetchContracts]);
+    fetchDeletedContracts();
+  }, [fetchContracts, fetchDeletedContracts]);
 
   useEffect(() => {
     if (selectedContractId) {
@@ -465,6 +522,12 @@ export default function ContractManagementScreen() {
   useEffect(() => {
     setShowAllContracts(false);
   }, [search]);
+
+  useEffect(() => {
+    if (deleteHistoryOpen) {
+      fetchDeletedContracts();
+    }
+  }, [deleteHistoryOpen, fetchDeletedContracts]);
 
   const selectedContract =
     contracts.find((contract) => contract.id === selectedContractId) ??
@@ -592,20 +655,6 @@ export default function ContractManagementScreen() {
 
       await client.delete(`/api/v1/contracts/${deleteTargetId}`);
 
-      if (target) {
-        const newRecord: Contract = {
-          ...target,
-          status: '삭제됨',
-          updatedAt: '방금 전',
-          deletedAt: new Date().toLocaleDateString('ko-KR'),
-        };
-        setDeletedContracts((prev) => {
-          const updated = [newRecord, ...prev];
-          localStorage.setItem('deletedContracts', JSON.stringify(updated));
-          return updated;
-        });
-      }
-
       const remaining = contracts.filter((contract) => contract.id !== deleteTargetId);
 
       setContracts(remaining);
@@ -613,6 +662,18 @@ export default function ContractManagementScreen() {
       setShowDeleteModal(false);
       setDeleteTargetId(null);
       setShowAllContracts(false);
+      if (target) {
+        setDeletedContracts((prev) => [
+          {
+            ...target,
+            status: '삭제됨',
+            updatedAt: '방금 전',
+            deletedAt: new Date().toLocaleDateString('ko-KR'),
+          },
+          ...prev.filter((contract) => contract.id !== target.id),
+        ]);
+      }
+      fetchDeletedContracts();
     } catch (error: any) {
       console.error('삭제 실패:', error?.response?.status, error?.response?.data);
       const detail = error?.response?.data?.detail || error?.response?.data?.message;
@@ -634,11 +695,15 @@ export default function ContractManagementScreen() {
       setAnalyzing(true);
 
       const analysisRequestedAt = new Date().toISOString();
-      await client.post(`/api/v1/contracts/${selectedContract.id}/analyze`, null, {
-        params: { force: true },
-      });
+      await requestAnalysis(selectedContract.id);
 
-      navigate(`/loading/${selectedContract.id}`, { state: { analysisRequestedAt } });
+      navigate(`/loading/${selectedContract.id}`, {
+        state: {
+          analysisRequestedAt,
+          expectedFileName: selectedContract.fileName,
+          requireFreshAnalysis: true,
+        },
+      });
     } catch (error: any) {
       const detail = error?.response?.data?.detail || error?.response?.data?.message;
 
@@ -962,6 +1027,18 @@ export default function ContractManagementScreen() {
                 onToggle={() => setDeleteHistoryOpen((prev) => !prev)}
               >
                 <div className="mx-auto w-full max-w-[900px] space-y-2.5">
+                  {loadingDeleteHistory && (
+                    <div className="rounded-[16px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center text-[12px] text-slate-400 sm:text-[13px]">
+                      삭제 이력을 불러오는 중이에요.
+                    </div>
+                  )}
+
+                  {!loadingDeleteHistory && deleteHistoryError && (
+                    <div className="rounded-[16px] border border-dashed border-rose-100 bg-rose-50 px-4 py-8 text-center text-[12px] text-rose-400 sm:text-[13px]">
+                      {deleteHistoryError}
+                    </div>
+                  )}
+
                   {deletedContracts.map((contract) => (
                     <div key={contract.id} className="rounded-[14px] border border-slate-100 bg-white p-3">
                       <div className="flex items-start gap-3">
@@ -990,7 +1067,7 @@ export default function ContractManagementScreen() {
                     </div>
                   ))}
 
-                  {deletedContracts.length === 0 && (
+                  {!loadingDeleteHistory && !deleteHistoryError && deletedContracts.length === 0 && (
                     <div className="rounded-[16px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center text-[12px] text-slate-400 sm:text-[13px]">
                       삭제된 계약서 이력이 없어요.
                     </div>

--- a/src/app/screens/Loading.tsx
+++ b/src/app/screens/Loading.tsx
@@ -55,11 +55,32 @@ const getLogTime = (log: any) => {
   return parsed && Number.isFinite(parsed) ? parsed : 0;
 };
 
+const extractContractId = (data: any) => {
+  const rawId =
+    data?.contract_id ??
+    data?.contractId ??
+    data?.contract?.contract_id ??
+    data?.contract?.contractId ??
+    data?.contract?.id ??
+    data?.data?.contract_id ??
+    data?.data?.contractId ??
+    data?.data?.contract?.contract_id ??
+    data?.data?.contract?.contractId ??
+    data?.data?.contract?.id ??
+    data?.data?.id ??
+    data?.id;
+
+  const id = Number(rawId);
+  return Number.isFinite(id) && id > 0 ? id : null;
+};
+
 export function Loading() {
   const { contractId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
   const analysisRequestedAt = (location.state as any)?.analysisRequestedAt;
+  const expectedFileName = (location.state as any)?.expectedFileName;
+  const requireFreshAnalysis = Boolean((location.state as any)?.requireFreshAnalysis);
 
   const [messages, setMessages] = useState<Message[]>([
     {
@@ -76,6 +97,7 @@ export function Loading() {
   const isStarted = useRef(false);
   const loadingStartedAt = useRef(Date.now());
   const staleResultMessageShown = useRef(false);
+  const announcedStepIndexes = useRef(new Set([0]));
 
   const steps: Step[] = useMemo(
     () => [
@@ -91,13 +113,20 @@ export function Loading() {
   useEffect(() => {
     if (isStarted.current) return;
     isStarted.current = true;
+    loadingStartedAt.current = Date.now();
 
     let pollInterval: number | undefined;
+    let fakeProgressInterval: number | undefined;
 
     const stopPolling = () => {
       if (pollInterval) {
         window.clearInterval(pollInterval);
         pollInterval = undefined;
+      }
+
+      if (fakeProgressInterval) {
+        window.clearInterval(fakeProgressInterval);
+        fakeProgressInterval = undefined;
       }
     };
 
@@ -213,6 +242,15 @@ export function Loading() {
 
         const response = await client.get(`/api/v1/contracts/${contractId}`);
         const data = response.data;
+        const responseContractId = extractContractId(data);
+
+        if (responseContractId !== null && responseContractId !== Number(contractId)) {
+          console.warn('계약서 ID가 일치하지 않아 폴링 응답을 무시합니다:', {
+            routeContractId: contractId,
+            responseContractId,
+          });
+          return;
+        }
 
         const rawStatus =
           statusData?.status ??
@@ -241,22 +279,6 @@ export function Loading() {
             statusFromStatusEndpoint === 'finished' ||
             statusFromStatusEndpoint.includes('완료'));
 
-        const isProcessing =
-          status === 'pending' ||
-          status === 'queued' ||
-          status === 'processing' ||
-          status === 'running' ||
-          status === 'analyzing' ||
-          status === 'in_progress' ||
-          status === 'progress' ||
-          status.includes('대기') ||
-          status.includes('진행') ||
-          status.includes('분석 중');
-
-        if (isProcessing) {
-          return;
-        }
-
         const realProgress = getRealProgress(statusData, data);
         const realStep = getRealStep(statusData, data);
         const realLogs = getRealLogs(statusData, data);
@@ -266,9 +288,11 @@ export function Loading() {
         }
 
         if (realStep !== null) {
-          setCurrentStep(realStep);
+          setCurrentStep((prev) => Math.max(prev, realStep));
         } else if (realProgress !== null) {
-          setCurrentStep(Math.min(steps.length - 1, Math.floor(realProgress / 25)));
+          setCurrentStep((prev) =>
+            Math.max(prev, Math.min(steps.length - 1, Math.floor(realProgress / 25))),
+          );
         }
 
         realLogs.forEach((log) => {
@@ -296,7 +320,7 @@ export function Loading() {
           if (realProgress === null) {
             const inferredStep = realStep ?? getStepFromText(status);
             if (inferredStep !== null) {
-              setCurrentStep(inferredStep);
+              setCurrentStep((prev) => Math.max(prev, inferredStep));
               setProgress((prev) => Math.max(prev, Math.min(90, 15 + inferredStep * 20)));
             }
           }
@@ -329,10 +353,10 @@ export function Loading() {
           parseTime(data?.contract?.analysis_completed_at) ??
           parseTime(data?.contract?.updated_at);
 
+        const hasFreshResultTime =
+          !requestedTime || (resultTime !== null && resultTime >= requestedTime - 3000);
         const hasFreshResult =
-          isCompletedFromStatusEndpoint ||
-          !requestedTime ||
-          (resultTime !== null && resultTime >= requestedTime - 3000);
+          hasFreshResultTime || (!requireFreshAnalysis && isCompletedFromStatusEndpoint);
 
         const hasResultPayload =
           !!data?.analysis ||
@@ -350,8 +374,7 @@ export function Loading() {
             status === 'analyzed' ||
             status === 'finished' ||
             status.includes('완료') ||
-            hasResultPayload) &&
-            (hasFreshResultTime || hasWaitedForReanalysis));
+            (hasResultPayload && hasFreshResultTime));
 
         if (isCompleted) {
           stopPolling();
@@ -361,7 +384,14 @@ export function Loading() {
           addBotMessage('분석이 완료되었어요. 결과 화면으로 이동할게요.');
 
           window.setTimeout(() => {
-            navigate(`/result/${contractId}`, { replace: true });
+            navigate(`/result/${contractId}`, {
+              replace: true,
+              state: {
+                analysisRequestedAt,
+                expectedFileName,
+                requireFreshAnalysis,
+              },
+            });
           }, 1200);
 
           return;
@@ -412,6 +442,23 @@ export function Loading() {
       pollInterval = window.setInterval(() => {
         pollStatus();
       }, 3000);
+
+      fakeProgressInterval = window.setInterval(() => {
+        setProgress((prev) => {
+          if (prev >= 90) return prev;
+
+          const elapsedSeconds = (Date.now() - loadingStartedAt.current) / 1000;
+          const increment =
+            elapsedSeconds < 8 ? 1.8 : elapsedSeconds < 25 ? 1.1 : 0.45;
+          const next = Math.min(90, prev + increment);
+
+          setCurrentStep((step) =>
+            Math.max(step, Math.min(steps.length - 2, Math.floor(next / 22))),
+          );
+
+          return next;
+        });
+      }, 1000);
     };
 
     const startLoading = () => {
@@ -431,7 +478,25 @@ export function Loading() {
       stopPolling();
       isStarted.current = false;
     };
-  }, [analysisRequestedAt, contractId, navigate, steps]);
+  }, [analysisRequestedAt, contractId, expectedFileName, navigate, requireFreshAnalysis, steps]);
+
+  useEffect(() => {
+    const step = steps[currentStep];
+    if (!step || announcedStepIndexes.current.has(currentStep)) return;
+
+    announcedStepIndexes.current.add(currentStep);
+    setMessages((prev) => {
+      if (prev.some((message) => message.text === step.message)) return prev;
+
+      return [
+        ...prev,
+        {
+          role: 'bot',
+          text: step.message,
+        },
+      ];
+    });
+  }, [currentStep, steps]);
 
   return (
     <div

--- a/src/app/screens/ProfileScreen.tsx
+++ b/src/app/screens/ProfileScreen.tsx
@@ -24,9 +24,11 @@ export default function ProfileScreen() {
   const [isEdit, setIsEdit] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
   const [showSaveToast, setShowSaveToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('프로필 정보가 저장되었습니다');
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [profileImage, setProfileImage] = useState<string | null>(null);
   const [savedProfileImage, setSavedProfileImage] = useState<string | null>(null);
   const [selectedProfileFile, setSelectedProfileFile] = useState<File | null>(null);
@@ -275,7 +277,29 @@ export default function ProfileScreen() {
   };
 
   const handleAccountDeleteClick = () => {
-    showToast('회원 탈퇴 API가 아직 제공되지 않았습니다.');
+    setShowDeleteAccountModal(true);
+  };
+
+  const handleDeleteAccount = async () => {
+    if (isDeletingAccount) return;
+
+    try {
+      setIsDeletingAccount(true);
+
+      await client.delete('/api/v1/auth/me');
+
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('userInfo');
+      localStorage.removeItem('profileImage');
+      setShowDeleteAccountModal(false);
+      navigate('/login', { replace: true });
+    } catch (error: any) {
+      console.error('회원 탈퇴 실패:', error);
+      showToast(getErrorMessage(error, '회원 탈퇴에 실패했습니다.'));
+    } finally {
+      setIsDeletingAccount(false);
+    }
   };
 
   const displayInitial = user.name ? user.name.charAt(0) : 'U';
@@ -692,6 +716,58 @@ export default function ProfileScreen() {
                 className="flex-1 rounded-xl py-2.5 text-[13px] font-semibold shadow-sm transition hover:opacity-90"
               >
                 로그아웃
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showDeleteAccountModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4 backdrop-blur-sm">
+          <div className="w-full max-w-[360px] rounded-2xl bg-white p-5 shadow-lg">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-[16px] font-semibold text-slate-900">
+                  계정을 탈퇴하시겠어요?
+                </h2>
+                <p className="mt-2 text-[13px] leading-5 text-slate-500">
+                  탈퇴하면 계정과 관련 데이터가 삭제되며 복구할 수 없습니다.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setShowDeleteAccountModal(false)}
+                disabled={isDeletingAccount}
+                className="text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="회원 탈퇴 취소"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="mt-6 flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowDeleteAccountModal(false)}
+                disabled={isDeletingAccount}
+                className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-[13px] font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                취소
+              </button>
+
+              <button
+                type="button"
+                onClick={handleDeleteAccount}
+                disabled={isDeletingAccount}
+                style={{
+                  backgroundColor: '#EF4444',
+                  color: '#FFFFFF',
+                  border: '1px solid #EF4444',
+                }}
+                className="flex-1 rounded-xl py-2.5 text-[13px] font-semibold shadow-sm transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isDeletingAccount ? '탈퇴 중...' : '탈퇴'}
               </button>
             </div>
           </div>

--- a/src/app/screens/ResultDashboard.tsx
+++ b/src/app/screens/ResultDashboard.tsx
@@ -52,6 +52,7 @@ type ComplianceItem = {
 type AnalysisResult = {
   fileName: string;
   analyzedDate: string;
+  contractSignedDate: string;
   safetyScore: number;
   contractType: string;
   contractStartDate: string;
@@ -73,6 +74,7 @@ type AnalysisResult = {
 const DEFAULT_ANALYSIS: AnalysisResult = {
   fileName: '근로계약서.pdf',
   analyzedDate: '분석 완료',
+  contractSignedDate: '-',
   safetyScore: 0,
   contractType: 'unknown',
   contractStartDate: '-',
@@ -126,6 +128,19 @@ function formatDate(value: unknown) {
   const day = String(date.getDate()).padStart(2, '0');
 
   return `${year}.${month}.${day} 분석 완료`;
+}
+
+function formatDateOnly(value: unknown, fallback = '-') {
+  if (!value) return fallback;
+
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) return String(value);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
 }
 
 function getKeyInfoValue(keyInfo: any, keys: string[], fallback = '-') {
@@ -209,6 +224,36 @@ function normalizeComplianceStatus(value: unknown): ComplianceStatus {
   return '검토불가';
 }
 
+function extractContractId(data: any) {
+  const rawId =
+    data?.contract_id ??
+    data?.contractId ??
+    data?.contract?.contract_id ??
+    data?.contract?.contractId ??
+    data?.contract?.id ??
+    data?.data?.contract_id ??
+    data?.data?.contractId ??
+    data?.data?.contract?.contract_id ??
+    data?.data?.contract?.contractId ??
+    data?.data?.contract?.id ??
+    data?.data?.id ??
+    data?.id;
+
+  const id = Number(rawId);
+  return Number.isFinite(id) && id > 0 ? id : null;
+}
+
+function normalizeFileNameForCompare(value: unknown) {
+  const text = String(value ?? '');
+
+  if (!/\.[a-z0-9]+$/i.test(text)) return '';
+
+  return text
+    .replace(/\s+/g, '')
+    .replace(/\.[^/.]+$/, '')
+    .toLowerCase();
+}
+
 function normalizeAnalysis(data: any): AnalysisResult {
   const source = data?.data?.contract ?? data?.contract ?? data?.data ?? data;
   const analysisSource =
@@ -225,6 +270,29 @@ function normalizeAnalysis(data: any): AnalysisResult {
     source?.key_info ??
     source?.keyInfo ??
     {};
+  const contractSignedDate = formatDateOnly(
+    getKeyInfoValue(
+      keyInfo,
+      [
+        'contract_date',
+        'contractDate',
+        'contract_signed_date',
+        'contractSignedDate',
+        'signed_date',
+        'signedDate',
+        'signature_date',
+        'signatureDate',
+        'execution_date',
+        'executionDate',
+        'agreement_date',
+        'agreementDate',
+        '계약체결일',
+        '체결일',
+        '작성일',
+      ],
+      '',
+    ),
+  );
   const riskSource =
     firstArray(
       source?.risk_clauses,
@@ -316,16 +384,20 @@ function normalizeAnalysis(data: any): AnalysisResult {
       data?.original_filename ??
       '근로계약서.pdf',
     contractType: String(source?.contract_type ?? analysisSource?.contract_type ?? 'unknown').toLowerCase(),
-    analyzedDate: formatDate(
-      source?.analysis_completed_at ??
-        analysisSource?.completed_at ??
-        analysisSource?.created_at ??
-        source?.updated_at ??
-        source?.created_at ??
-        data?.analysis_completed_at ??
-        data?.updated_at ??
-        data?.created_at,
-    ),
+    analyzedDate:
+      contractSignedDate !== '-'
+        ? `${contractSignedDate} 분석 완료`
+        : formatDate(
+            source?.analysis_completed_at ??
+              analysisSource?.completed_at ??
+              analysisSource?.created_at ??
+              source?.updated_at ??
+              source?.created_at ??
+              data?.analysis_completed_at ??
+              data?.updated_at ??
+              data?.created_at,
+          ),
+    contractSignedDate,
     safetyScore:
       Number(
         source?.safety_score ??
@@ -444,6 +516,7 @@ export function ResultDashboard() {
     params.id ??
     (location.state as any)?.contractId ??
     (location.state as any)?.id;
+  const expectedFileName = (location.state as any)?.expectedFileName;
 
   const [analysis, setAnalysis] = useState<AnalysisResult>(DEFAULT_ANALYSIS);
   const [isLoading, setIsLoading] = useState(true);
@@ -559,7 +632,23 @@ export function ResultDashboard() {
         }
 
         const response = await client.get(`/api/v1/contracts/${contractId}`);
+        const responseContractId = extractContractId(response.data);
+
+        if (responseContractId !== null && responseContractId !== Number(contractId)) {
+          throw new Error(
+            `요청한 계약서(${contractId})와 다른 계약서(${responseContractId}) 응답을 받았습니다.`,
+          );
+        }
+
         const normalized = normalizeAnalysis(response.data);
+        const expectedName = normalizeFileNameForCompare(expectedFileName);
+        const responseName = normalizeFileNameForCompare(normalized.fileName);
+
+        if (expectedName && responseName && expectedName !== responseName) {
+          throw new Error(
+            `요청한 파일(${expectedFileName})과 다른 계약서(${normalized.fileName}) 응답을 받았습니다.`,
+          );
+        }
 
         setAnalysis(normalized);
 
@@ -578,6 +667,11 @@ export function ResultDashboard() {
         ]);
       } catch (error) {
         console.error('분석 결과 조회 실패:', error);
+        setAnalysis({
+          ...DEFAULT_ANALYSIS,
+          fileName: '분석 결과를 불러오지 못했어요',
+          summaryText: '요청한 계약서와 다른 결과가 응답되었거나 분석 결과 조회에 실패했습니다.',
+        });
 
         setDashboardMessages([
           {
@@ -658,6 +752,14 @@ export function ResultDashboard() {
     try {
       const response = await client.get(`/api/v1/contracts/${contractId}/download/pdf`, {
         responseType: 'blob',
+        params:
+          analysis.contractSignedDate !== '-'
+            ? {
+                report_date: analysis.contractSignedDate,
+                contract_date: analysis.contractSignedDate,
+                contract_signed_date: analysis.contractSignedDate,
+              }
+            : undefined,
       });
 
       const blob = new Blob([response.data], { type: 'application/pdf' });
@@ -1179,6 +1281,8 @@ export function ResultDashboard() {
               <p className="mx-auto max-w-full break-words text-center text-[12px] leading-5 text-slate-500">
                 {analysis.monthlyWageIsEstimated
                   ? '시간급 기반으로 계산한 추정 금액이에요.'
+                  : analysis.monthlyWage && analysis.salaryDetail !== '-'
+                  ? `연봉 ${analysis.salaryDetail}`
                   : analysis.salaryDetail}
               </p>
             </div>

--- a/src/app/screens/Upload.tsx
+++ b/src/app/screens/Upload.tsx
@@ -21,6 +21,41 @@ type Message = {
   text: string;
 };
 
+const extractUploadedContractId = (data: any) => {
+  const rawId =
+    data?.contract_id ??
+    data?.contractId ??
+    data?.contract?.contract_id ??
+    data?.contract?.contractId ??
+    data?.contract?.id ??
+    data?.data?.contract_id ??
+    data?.data?.contractId ??
+    data?.data?.contract?.contract_id ??
+    data?.data?.contract?.contractId ??
+    data?.data?.contract?.id ??
+    data?.data?.id ??
+    data?.id;
+
+  const id = Number(rawId);
+  return Number.isFinite(id) && id > 0 ? id : null;
+};
+
+const requestAnalysis = async (contractId: number) => {
+  try {
+    return await client.post(`/api/v1/contracts/${contractId}/analyze`, null, {
+      params: { force: true },
+    });
+  } catch (error: any) {
+    if (![404, 405, 422].includes(error?.response?.status)) {
+      throw error;
+    }
+
+    return client.post(`/api/v1/contracts/${contractId}/request-analysis`, null, {
+      params: { force: true },
+    });
+  }
+};
+
 export function Upload() {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -182,7 +217,7 @@ export function Upload() {
         },
       });
 
-      const contractId = uploadResponse.data?.id;
+      const contractId = extractUploadedContractId(uploadResponse.data);
 
       if (!contractId) {
         throw new Error('업로드 응답에서 계약서 ID를 찾을 수 없습니다.');
@@ -190,11 +225,14 @@ export function Upload() {
 
       // 2. 분석 요청
       const analysisRequestedAt = new Date().toISOString();
-      await client.post(`/api/v1/contracts/${contractId}/analyze`, null, {
-        params: { force: true },
-      });
+      await requestAnalysis(contractId);
 
-      navigate(`/loading/${contractId}`, { state: { analysisRequestedAt } });
+      navigate(`/loading/${contractId}`, {
+        state: {
+          analysisRequestedAt,
+          expectedFileName: uploadedFile,
+        },
+      });
     } catch (error: any) {
       console.error('업로드/분석 요청 에러:', error);
       const detail = error.response?.data?.detail || '서버 통신 중 오류가 발생했습니다.';


### PR DESCRIPTION
## 관련 이슈
Closes #108 

## 변경 사항
`clair-frontend` 프로젝트의 주요 API 연동 및 비동기 분석 흐름의 예외 처리를 대폭 강화하여 전반적인 UI/UX 신뢰성을 높였습니다.

1. **회원 탈퇴 API 연동 (`ProfileScreen.tsx`)**
   - 탈퇴 API(`DELETE /api/v1/auth/me`)를 연결하고 중복 클릭 방지 로직을 추가했습니다.
   - 탈퇴 성공 시 localStorage의 모든 인증 정보(`accessToken`, `refreshToken` 등)를 클리어하고 `/login`으로 이동시킵니다.
   - 탈퇴 버튼의 가독성 문제(글자 안 보임)를 인라인 스타일 수정을 통해 해결했습니다.

2. **계약서 삭제 이력 조회 API 연동 (`ContractManagementScreen.tsx`)**
   - 로컬 스토리지 기반 초기화를 제거하고 `GET /api/v1/contracts/deleted`를 연동했습니다.
   - 서버의 다양한 응답 규격(`history`, `items`, `data` 등)에 유연하게 대응하는 방어 코드를 작성했습니다.
   - 화면 진입, 섹션 토글, 계약서 삭제 직후 자동으로 이력을 최신순 정렬하여 재조회하도록 구현했습니다.

3. **로딩 화면 컴파일 에러 해결 및 가상 폴링 추가 (`Loading.tsx`)**
   - `isProcessing` 중복 선언 및 미정의 변수 참조 등 Vite 빌드 에러를 유발하던 괄호/코드를 정리했습니다.
   - 서버의 실제 progress 값이 없을 때 화면이 멈춘 것처럼 보이지 않도록, 1초마다 20% -> 최대 90%까지 서서히 오르는 Fake Polling을 추가했습니다. (실제 API 호출은 3초 주기 유지)

4. **로딩 단계 깜빡임 방지 및 챗봇 멘트 복구 (`Loading.tsx`)**
   - `Math.max(prev, next)`를 활용해 단계를 업데이트함으로써 progress 수치 변동으로 인해 체크 표시가 뒤로 밀리며 깜빡이는 현상을 해결했습니다.
   - `announcedStepIndexes` ref를 도입하여 단계 진행에 따른 AI 챗봇 멘트가 중복 없이 순차적으로 출력되도록 복구했습니다.

5. **데이터 튐(Race Condition) 방지 및 호환 엔드포인트 대응**
   - 분석 요청 시 `/analyze?force=true`가 실패하면 자동으로 `/request-analysis?force=true`로 호환 요청을 보내도록 Fallback을 추가했습니다.
   - 응답 객체에서 `contract_id` 계열 필드를 우선적으로 파싱하여 다른 리소스 ID와 오인하는 문제를 차단했습니다.
   - 업로드 및 재분석 시작 시 `expectedFileName`과 URL의 ID를 검증하여, 다른 계약서의 결과가 노출되거나 이전 분석 결과로 화면이 먼저 튀는 현상을 방지했습니다.

6. **결과 화면 데이터 표기 보강 (`ResultDashboard.tsx`)**
   - 다양한 체결일 필드 후보군을 탐색·파싱하여 상단 날짜 UI에 반영하고 PDF 다운로드 쿼리 파라미터로 연동했습니다.
   - 월 급여 카드 하단에 연봉 금액임을 명시(`연봉 X,XXX원`)하여 가독성을 높였습니다.

## 변경 유형
- [x] 새 기능 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 문서 수정 (`docs`)
- [ ] 코드 리팩터링 (`refactor`)
- [ ] 테스트 추가 (`test`)
- [x] 빌드/설정 변경 (`chore`) ## 테스트 체크리스트
- [ ] 로컬에서 AI 서비스 정상 기동 확인 (`uvicorn src.api.main:app --port 8001`)
- [x] 분석 파이프라인 단계별 동작 확인 - [x] 기존 기능 동작에 영향 없음 확인 ## 리뷰어를 위한 참고 사항
- **비동기 방어 로직**: 백엔드 네트워크 지연이나 다양한 응답 규격 환경에서도 화면이 깨지거나 멈추지 않도록 `expectedFileName`, 호환 엔드포인트 Fallback, 응답 포맷 다중 대응 구조를 신경 써서 작성했습니다. 이 부분의 흐름을 중점적으로 봐주시면 감사하겠습니다.
- **재분석 타임스탬프 처리**: 기존 계약서 재분석 시 이전 결과가 노출되는 엣지 케이스를 막기 위해 `requireFreshAnalysis` 플래그와 수정 타임스탬프 교차 검증을 도입했습니다.
- 여러 차례 `npm run build`를 수행하여 빌드에 이상이 없음을 확인했습니다. (현재 프로젝트 내 별도의 테스트/린트 스크립트는 존재하지 않습니다.)