### PR TITLE
fix: 주휴수당 없으면 '해당 없음' 대신 항목 자체 숨김

### DIFF
--- a/src/app/screens/ResultDashboard.tsx
+++ b/src/app/screens/ResultDashboard.tsx
@@ -1327,22 +1327,14 @@ export function ResultDashboard() {
                 </div>
               )}
 
-              <div className="min-h-[78px] rounded-[14px] bg-slate-50 px-4 py-3">
-                <p className="text-center text-[11px] text-slate-500">주휴수당</p>
-                <p className="mt-1 break-words text-center text-[15px] font-semibold leading-6 text-slate-900">
-                  {weeklyHolidayPay > 0 ? (
-                    `월 ${formatWon(weeklyHolidayPay)}`
-                  ) : (
-                    <span className="text-[13px] text-slate-400">해당 없음</span>
-                  )}
-                </p>
-
-                {analysis.weeklyWorkHours && analysis.weeklyWorkHours < 15 && (
-                  <p className="mt-0.5 text-center text-[10px] text-slate-400">
-                    주 15시간 미만
+              {weeklyHolidayPay > 0 && (
+                <div className="min-h-[78px] rounded-[14px] bg-slate-50 px-4 py-3">
+                  <p className="text-center text-[11px] text-slate-500">주휴수당</p>
+                  <p className="mt-1 break-words text-center text-[15px] font-semibold leading-6 text-slate-900">
+                    월 {formatWon(weeklyHolidayPay)}
                   </p>
-                )}
-              </div>
+                </div>
+              )}
 
               {analysis.monthlyWage && (
                 <div


### PR DESCRIPTION
## 요약
분석 결과 급여 산출 내역에서 주휴수당이 없을 때 "해당 없음"이 뜨던 것을, 항목 자체가 안 보이도록 수정.

## 변경
- `src/app/screens/ResultDashboard.tsx`: 주휴수당 블록을 `{weeklyHolidayPay > 0 && (...)}`로 감싸 값이 있을 때만 렌더 (다른 급여 항목과 동일한 패턴)
- "해당 없음" 문구 제거
- 주휴수당 0일 때만 뜨던 "주 15시간 미만" 보조 문구도 죽은 코드라 제거

## 검증
- 주휴수당 없는 계약서(주 15시간 미만 등) → 해당 칸 미표시 확인
- 주휴수당 있는 계약서 → 기존대로 "월 OOO원" 표시

Closes #110