### PR TITLE
chore: 배포 준비 — Vercel 설정 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 요약

정적 호스팅 배포를 위한 Vercel 설정을 추가했다.

## vercel.json

SPA라 `/result/:contractId` 같은 딥링크로 **직접 진입하면 404가 난다.** 정적 호스팅은 해당 경로의 파일을 찾기 때문이다. 모든 경로를 `index.html`로 rewrite하도록 설정했다.

```json
"rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
```

## 배포 시 주의

`VITE_*` 변수는 **빌드 시점에 번들로 인라인된다.** 런타임에 읽는 것이 아니므로, 배포 플랫폼 환경변수에 `VITE_API_URL`을 백엔드 주소로 설정한 **뒤에** 빌드해야 한다. 나중에 값만 바꾸면 재빌드 전까지 반영되지 않는다.

## 검증

`npm ci && npm run build` 성공 (2079 모듈, 2.3초).
